### PR TITLE
Add news detail page and bootstrap cards

### DIFF
--- a/backend/controllers/newsController.js
+++ b/backend/controllers/newsController.js
@@ -32,3 +32,13 @@ exports.getNews = async (req, res) => {
     res.status(500).json({ msg: 'Error al obtener noticias' });
   }
 };
+
+exports.getNewsById = async (req, res) => {
+  try {
+    const noticia = await News.findById(req.params.id).populate('autor', 'nombre apellido');
+    if (!noticia) return res.status(404).json({ msg: 'Noticia no encontrada' });
+    res.json(noticia);
+  } catch (err) {
+    res.status(500).json({ msg: 'Error al obtener la noticia' });
+  }
+};

--- a/backend/routes/newsRoutes.js
+++ b/backend/routes/newsRoutes.js
@@ -8,5 +8,6 @@ const upload = require('../middleware/upload');
 // rutas
 router.post('/', auth, checkRole(['Tecnico', 'Delegado']), upload.single('imagen'), newsController.createNews);
 router.get('/', auth, newsController.getNews);
+router.get('/:id', auth, newsController.getNewsById);
 
 module.exports = router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -22,6 +22,7 @@ import ResultadosClubCompetencia from './pages/ResultadosClubCompetencia';
 import CrearTituloIndividual from './pages/CrearTituloIndividual';
 import CrearTituloClub from './pages/CrearTituloClub';
 import Titulos from './pages/Titulos';
+import NoticiaDetalle from './pages/NoticiaDetalle';
 const App = () => {
   return (
     <Routes>
@@ -31,7 +32,8 @@ const App = () => {
 
       <Route path="/" element={<ProtectedRoute><Layout /></ProtectedRoute>}>
        <Route path="dashboard" element={<Dashboard />} />
-  <Route path="crear-noticia" element={<CrearNoticia />} />
+       <Route path="crear-noticia" element={<CrearNoticia />} />
+       <Route path="noticia/:id" element={<NoticiaDetalle />} />
         <Route path="mis-patinadores" element={<MisPatinadores />} />
           <Route path="crear-patinador" element={<CrearPatinador />} />
            <Route path="patinadores" element={<Patinadores />} />

--- a/frontend/src/api/news.js
+++ b/frontend/src/api/news.js
@@ -21,3 +21,10 @@ export const getNoticias = async (token) => {
   });
   return res.data;
 };
+
+export const getNoticia = async (id, token) => {
+  const res = await api.get(`/news/${id}`, {
+    headers: { Authorization: token }
+  });
+  return res.data;
+};

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import useAuth from '../store/useAuth';
 import { getNoticias } from '../api/news';
 
@@ -22,30 +23,45 @@ const Dashboard = () => {
 
   return (
     <div>
-      <h2>Últimas Noticias</h2>
+      <h2 className="mb-4">Últimas Noticias</h2>
 
       {noticias.length === 0 && <p>No hay noticias disponibles.</p>}
 
-      <ul className="list-group">
+      <div className="row">
         {noticias.map(noticia => (
-          <li key={noticia._id} className="list-group-item mb-3">
-            <h3>{noticia.titulo}</h3>
-            <p>{noticia.contenido}</p>
-
-            {noticia.imagen && (
-              <div>
-                <img 
-                  src={`http://localhost:5000/uploads/${noticia.imagen}`} 
-                  alt="Imagen noticia" 
-                  style={{ maxWidth: '100%', maxHeight: '300px' }} 
+          <div key={noticia._id} className="col-md-6 col-lg-4 mb-4">
+            <div className="card h-100">
+              {noticia.imagen && (
+                <img
+                  src={`http://localhost:5000/uploads/${noticia.imagen}`}
+                  className="card-img-top"
+                  alt="Imagen noticia"
+                  style={{ objectFit: 'cover', height: '200px' }}
                 />
+              )}
+              <div className="card-body d-flex flex-column">
+                <h5 className="card-title">{noticia.titulo}</h5>
+                <p className="card-text">
+                  {noticia.contenido.length > 120
+                    ? `${noticia.contenido.substring(0, 120)}...`
+                    : noticia.contenido}
+                </p>
+                <div className="mt-auto">
+                  <Link to={`/noticia/${noticia._id}`} className="btn btn-primary">
+                    Más info
+                  </Link>
+                </div>
               </div>
-            )}
-
-            <small>Por: {noticia.autor.nombre} {noticia.autor.apellido} - {new Date(noticia.fecha).toLocaleString()}</small>
-          </li>
+              <div className="card-footer">
+                <small className="text-muted">
+                  Por: {noticia.autor.nombre} {noticia.autor.apellido} -{' '}
+                  {new Date(noticia.fecha).toLocaleString()}
+                </small>
+              </div>
+            </div>
+          </div>
         ))}
-      </ul>
+      </div>
     </div>
   );
 };

--- a/frontend/src/pages/NoticiaDetalle.jsx
+++ b/frontend/src/pages/NoticiaDetalle.jsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import useAuth from '../store/useAuth';
+import { getNoticia } from '../api/news';
+
+const NoticiaDetalle = () => {
+  const { id } = useParams();
+  const { token } = useAuth();
+  const [noticia, setNoticia] = useState(null);
+
+  useEffect(() => {
+    const fetchNoticia = async () => {
+      try {
+        const data = await getNoticia(id, token);
+        setNoticia(data);
+      } catch (err) {
+        console.error(err);
+        alert('Error al cargar la noticia');
+      }
+    };
+    fetchNoticia();
+  }, [id, token]);
+
+  if (!noticia) return <p>Cargando...</p>;
+
+  return (
+    <div className="card">
+      {noticia.imagen && (
+        <img
+          src={`http://localhost:5000/uploads/${noticia.imagen}`}
+          className="card-img-top"
+          alt="Imagen noticia"
+          style={{ objectFit: 'cover', maxHeight: '400px' }}
+        />
+      )}
+      <div className="card-body">
+        <h3 className="card-title">{noticia.titulo}</h3>
+        <p className="card-text">{noticia.contenido}</p>
+      </div>
+      <div className="card-footer">
+        <small className="text-muted">
+          Por: {noticia.autor.nombre} {noticia.autor.apellido} -{' '}
+          {new Date(noticia.fecha).toLocaleString()}
+        </small>
+      </div>
+    </div>
+  );
+};
+
+export default NoticiaDetalle;


### PR DESCRIPTION
## Summary
- create controller and route to fetch individual news
- add API wrapper for getting single news
- show news as responsive bootstrap cards with snippet
- link to new NoticiaDetalle page with full content
- add route to display news detail

## Testing
- `npm test` in backend (fails: no test specified)
- `npm test` in frontend (fails: missing script)


------
https://chatgpt.com/codex/tasks/task_e_685683252e5883208d4837a7e6a23bd9