### PR TITLE
Implement competition management

### DIFF
--- a/backend/controllers/competenciasController.js
+++ b/backend/controllers/competenciasController.js
@@ -1,4 +1,6 @@
 const Competencia = require('../models/Competencia');
+const User = require('../models/User');
+const sendEmail = require('../utils/sendEmail');
 
 exports.crearCompetencia = async (req, res) => {
   try {
@@ -7,11 +9,30 @@ exports.crearCompetencia = async (req, res) => {
     const competencia = new Competencia({
       nombre,
       fecha,
+      creador: req.user.id,
       resultados: [],
-      resultadosClub: []
+      resultadosClub: [],
+      listaBuenaFe: [],
+      padronSeguros: []
     });
 
     await competencia.save();
+
+    try {
+      const users = await User.find();
+      const linksBase = `${process.env.CLIENT_URL}/competencias/${competencia._id}/confirmar`;
+      for (const u of users) {
+        await sendEmail(
+          u.email,
+          'Nueva competencia',
+          `<p>Se ha creado la competencia ${nombre} el ${new Date(fecha).toLocaleDateString()}.</p>
+           <p>Confirma tu participación:</p>
+           <a href="${linksBase}?respuesta=SI">Participar</a> | <a href="${linksBase}?respuesta=NO">No participar</a>`
+        );
+      }
+    } catch (e) {
+      console.error('Error al enviar notificaciones:', e);
+    }
     res.json({ msg: 'Competencia creada correctamente' });
 
   } catch (err) {
@@ -61,5 +82,61 @@ exports.agregarResultadosClub = async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(500).json({ msg: 'Error al cargar resultados de clubes' });
+  }
+};
+
+exports.editarCompetencia = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { nombre, fecha } = req.body;
+    await Competencia.findByIdAndUpdate(id, { nombre, fecha });
+    res.json({ msg: 'Competencia actualizada' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: 'Error al editar competencia' });
+  }
+};
+
+exports.eliminarCompetencia = async (req, res) => {
+  try {
+    const { id } = req.params;
+    await Competencia.findByIdAndDelete(id);
+    res.json({ msg: 'Competencia eliminada' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: 'Error al eliminar competencia' });
+  }
+};
+
+exports.confirmarParticipacion = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { respuesta } = req.body;
+    const competencia = await Competencia.findById(id).populate('creador');
+    if (!competencia) return res.status(404).json({ msg: 'Competencia no encontrada' });
+
+    const usuario = await User.findById(req.user.id);
+
+    if (respuesta === 'SI') {
+      if (!competencia.listaBuenaFe.includes(usuario._id)) {
+        competencia.listaBuenaFe.push(usuario._id);
+        await competencia.save();
+      }
+      return res.json({ msg: 'Participación confirmada' });
+    }
+
+    try {
+      await sendEmail(
+        competencia.creador.email,
+        'Participación rechazada',
+        `<p>${usuario.nombre} ${usuario.apellido} no participará en ${competencia.nombre}.</p>`
+      );
+    } catch (e) {
+      console.error('Error al notificar al delegado', e);
+    }
+    res.json({ msg: 'Respuesta registrada' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: 'Error al confirmar participación' });
   }
 };

--- a/backend/models/Competencia.js
+++ b/backend/models/Competencia.js
@@ -9,11 +9,14 @@ const resultadoSchema = new mongoose.Schema({
 const competenciaSchema = new mongoose.Schema({
   nombre: { type: String, required: true },
   fecha: { type: Date, required: true },
+  creador: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   resultados: [resultadoSchema],
-  resultadosClub: [{ 
+  resultadosClub: [{
     club: { type: String, required: true },
     puntos: { type: Number, required: true }
-  }]
+  }],
+  listaBuenaFe: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
+  padronSeguros: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }]
 });
 
 module.exports = mongoose.model('Competencia', competenciaSchema);

--- a/backend/routes/competenciasRoutes.js
+++ b/backend/routes/competenciasRoutes.js
@@ -9,6 +9,9 @@ router.post('/', auth, checkRole(['Delegado']), competenciasController.crearComp
 router.put('/resultados', auth, checkRole(['Delegado']), competenciasController.agregarResultados);
 router.get('/', auth, competenciasController.listarCompetencias);
 router.put('/resultados-club', auth, checkRole(['Delegado']), competenciasController.agregarResultadosClub);
+router.put('/:id', auth, checkRole(['Delegado']), competenciasController.editarCompetencia);
+router.delete('/:id', auth, checkRole(['Delegado']), competenciasController.eliminarCompetencia);
+router.post('/:id/confirmar', auth, competenciasController.confirmarParticipacion);
 
 
 module.exports = router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,7 @@ import Patinadores from './pages/Patinadores';
 import EditarPatinador from './pages/EditarPatinador';
 import VerPatinador from './pages/VerPatinador';
 import CrearCompetencia from './pages/CrearCompetencia';
+import EditarCompetencia from './pages/EditarCompetencia';
 import Competencias from './pages/Competencias';
 import ResultadosCompetencia from './pages/ResultadosCompetencia';
 import ResultadosDetalle from './pages/ResultadosDetalle';
@@ -23,6 +24,7 @@ import CrearTituloIndividual from './pages/CrearTituloIndividual';
 import CrearTituloClub from './pages/CrearTituloClub';
 import Titulos from './pages/Titulos';
 import NoticiaDetalle from './pages/NoticiaDetalle';
+import ConfirmarCompetencia from './pages/ConfirmarCompetencia';
 const App = () => {
   return (
     <Routes>
@@ -41,8 +43,10 @@ const App = () => {
            <Route path="patinador/:id" element={<VerPatinador />} />
            <Route path="crear-competencia" element={<CrearCompetencia />} />
           <Route path="competencias" element={<Competencias />} />
+          <Route path="competencias/editar/:id" element={<EditarCompetencia />} />
           <Route path="competencias/:id/resultados" element={<ResultadosCompetencia />} />
           <Route path="competencias/:id/detalle" element={<ResultadosDetalle />} />
+          <Route path="competencias/:id/confirmar" element={<ConfirmarCompetencia />} />
           <Route path="ranking" element={<RankingGeneral />} />
            <Route path="ranking-categorias" element={<RankingPorCategorias />} />
            <Route path="competencias/:id/resultados-club" element={<ResultadosClubCompetencia />} />

--- a/frontend/src/api/competencias.js
+++ b/frontend/src/api/competencias.js
@@ -30,3 +30,24 @@ export const agregarResultadosClub = async (data, token) => {
   });
   return res.data;
 };
+
+export const editarCompetencia = async (id, data, token) => {
+  const res = await api.put(`/competencias/${id}`, data, {
+    headers: { Authorization: token }
+  });
+  return res.data;
+};
+
+export const eliminarCompetencia = async (id, token) => {
+  const res = await api.delete(`/competencias/${id}`, {
+    headers: { Authorization: token }
+  });
+  return res.data;
+};
+
+export const confirmarCompetencia = async (id, respuesta, token) => {
+  const res = await api.post(`/competencias/${id}/confirmar`, { respuesta }, {
+    headers: { Authorization: token }
+  });
+  return res.data;
+};

--- a/frontend/src/pages/Competencias.jsx
+++ b/frontend/src/pages/Competencias.jsx
@@ -1,12 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import useAuth from '../store/useAuth';
-import { listarCompetencias } from '../api/competencias';
+import { listarCompetencias, eliminarCompetencia } from '../api/competencias';
 import { useNavigate } from 'react-router-dom';
 
 const Competencias = () => {
-  const { token } = useAuth();
+  const { token, user } = useAuth();
   const [competencias, setCompetencias] = useState([]);
   const navigate = useNavigate();
+  const isDelegado = user?.role === 'Delegado';
 
   const fetchCompetencias = async () => {
     try {
@@ -26,6 +27,21 @@ const Competencias = () => {
     navigate(`/competencias/${id}/resultados`);
   };
 
+  const handleEditar = (id) => {
+    navigate(`/competencias/editar/${id}`);
+  };
+
+  const handleEliminar = async (id) => {
+    if (!window.confirm('¿Eliminar competencia?')) return;
+    try {
+      await eliminarCompetencia(id, token);
+      fetchCompetencias();
+    } catch (err) {
+      console.error(err);
+      alert('Error al eliminar');
+    }
+  };
+
   return (
     <div>
       <h2>Competencias</h2>
@@ -34,6 +50,12 @@ const Competencias = () => {
           <li key={c._id} className="list-group-item d-flex justify-content-between align-items-center">
             <span><strong>{c.nombre}</strong> - {new Date(c.fecha).toLocaleDateString()}</span>
             <div>
+              {isDelegado && (
+                <>
+                  <button className="btn btn-sm btn-warning me-2" onClick={() => handleEditar(c._id)}>Editar</button>
+                  <button className="btn btn-sm btn-danger me-2" onClick={() => handleEliminar(c._id)}>Eliminar</button>
+                </>
+              )}
               <button className="btn btn-sm btn-secondary me-2" onClick={() => handleResultados(c._id)}>Cargar Resultados</button>
               <button className="btn btn-sm btn-primary" onClick={() => navigate(`/competencias/${c._id}/detalle`)}>Ver Resultados</button>
             </div>

--- a/frontend/src/pages/ConfirmarCompetencia.jsx
+++ b/frontend/src/pages/ConfirmarCompetencia.jsx
@@ -1,0 +1,31 @@
+import React, { useEffect } from 'react';
+import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
+import useAuth from '../store/useAuth';
+import { confirmarCompetencia } from '../api/competencias';
+
+const ConfirmarCompetencia = () => {
+  const { token } = useAuth();
+  const { id } = useParams();
+  const [search] = useSearchParams();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const enviar = async () => {
+      const respuesta = search.get('respuesta');
+      if (!respuesta) return;
+      try {
+        await confirmarCompetencia(id, respuesta, token);
+        alert('Respuesta registrada');
+      } catch (err) {
+        console.error(err);
+        alert('Error al confirmar');
+      }
+      navigate('/competencias');
+    };
+    enviar();
+  }, []);
+
+  return <p>Procesando...</p>;
+};
+
+export default ConfirmarCompetencia;

--- a/frontend/src/pages/EditarCompetencia.jsx
+++ b/frontend/src/pages/EditarCompetencia.jsx
@@ -1,0 +1,53 @@
+import React, { useState, useEffect } from 'react';
+import useAuth from '../store/useAuth';
+import { editarCompetencia, listarCompetencias } from '../api/competencias';
+import { useNavigate, useParams } from 'react-router-dom';
+
+const EditarCompetencia = () => {
+  const { token } = useAuth();
+  const navigate = useNavigate();
+  const { id } = useParams();
+
+  const [form, setForm] = useState({ nombre: '', fecha: '' });
+
+  useEffect(() => {
+    const cargar = async () => {
+      const comps = await listarCompetencias(token);
+      const comp = comps.find(c => c._id === id);
+      if (comp) {
+        setForm({ nombre: comp.nombre, fecha: comp.fecha.substring(0, 10) });
+      }
+    };
+    cargar();
+  }, []);
+
+  const handleChange = e => {
+    const { name, value } = e.target;
+    setForm(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    try {
+      await editarCompetencia(id, form, token);
+      alert('Competencia actualizada');
+      navigate('/competencias');
+    } catch (err) {
+      console.error(err);
+      alert('Error al actualizar');
+    }
+  };
+
+  return (
+    <div>
+      <h2>Editar Competencia</h2>
+      <form onSubmit={handleSubmit}>
+        <input name="nombre" value={form.nombre} onChange={handleChange} required />
+        <input type="date" name="fecha" value={form.fecha} onChange={handleChange} required />
+        <button type="submit">Guardar</button>
+      </form>
+    </div>
+  );
+};
+
+export default EditarCompetencia;


### PR DESCRIPTION
## Summary
- extend Competencia model with creator and participant lists
- notify all users by email when a competition is created
- allow delegates to edit or delete competitions
- allow users to confirm participation
- expose edit/delete/confirm endpoints
- add editing and confirmation pages
- show edit and delete buttons in competitions list

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` in backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6857d4034e988320afcb9d0ac1df2811