### PR TITLE
Add profile avatar and notification bell

### DIFF
--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -1,0 +1,23 @@
+const User = require('../models/User');
+
+exports.getCurrentUser = async (req, res) => {
+  try {
+    const user = await User.findById(req.user.id).select('nombre apellido email role picture googleId');
+    if (!user) return res.status(404).json({ msg: 'Usuario no encontrado' });
+    res.json(user);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: 'Error al obtener usuario' });
+  }
+};
+
+exports.updateProfilePicture = async (req, res) => {
+  try {
+    if (!req.file) return res.status(400).json({ msg: 'No se subió ninguna imagen' });
+    await User.findByIdAndUpdate(req.user.id, { picture: req.file.filename });
+    res.json({ msg: 'Foto de perfil actualizada', picture: req.file.filename });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: 'Error al actualizar foto de perfil' });
+  }
+};

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+const userController = require('../controllers/userController');
+const auth = require('../middleware/authMiddleware');
+const upload = require('../middleware/upload');
+
+router.get('/me', auth, userController.getCurrentUser);
+router.put('/picture', auth, upload.single('picture'), userController.updateProfilePicture);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -20,6 +20,7 @@ app.use('/api/competencias', require('./routes/competenciasRoutes'));
 app.use('/api/ranking', require('./routes/rankingRoutes'));
 app.use('/api/titulos', require('./routes/titulosRoutes'));
 app.use('/api/notificaciones', require('./routes/notificationRoutes'));
+app.use('/api/usuarios', require('./routes/userRoutes'));
 
 
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
     <title>Vite + React</title>
   </head>
   <body>

--- a/frontend/src/api/usuarios.js
+++ b/frontend/src/api/usuarios.js
@@ -1,0 +1,17 @@
+import api from './api';
+
+export const getMe = async (token) => {
+  const res = await api.get('/usuarios/me', {
+    headers: { Authorization: token },
+  });
+  return res.data;
+};
+
+export const updateProfilePicture = async (file, token) => {
+  const formData = new FormData();
+  formData.append('picture', file);
+  const res = await api.put('/usuarios/picture', formData, {
+    headers: { Authorization: token, 'Content-Type': 'multipart/form-data' },
+  });
+  return res.data;
+};


### PR DESCRIPTION
## Summary
- add user controller and routes to get current user and update picture
- expose new user routes from Express server
- add frontend API for user profile
- enhance Navbar with notification bell and profile avatar
- include Bootstrap Icons in HTML

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685921de1ffc8320a6eb029b0da5afed