### PR TITLE
Add interactive notifications

### DIFF
--- a/backend/controllers/competenciasController.js
+++ b/backend/controllers/competenciasController.js
@@ -32,7 +32,8 @@ exports.crearCompetencia = async (req, res) => {
         );
         await Notification.create({
           usuario: u._id,
-          mensaje: `Se ha creado la competencia ${nombre} el ${new Date(fecha).toLocaleDateString()}.`
+          mensaje: `Se ha creado la competencia ${nombre} el ${new Date(fecha).toLocaleDateString()}.`,
+          competencia: competencia._id
         });
       }
     } catch (e) {
@@ -138,7 +139,8 @@ exports.confirmarParticipacion = async (req, res) => {
       );
       await Notification.create({
         usuario: competencia.creador._id,
-        mensaje: `${usuario.nombre} ${usuario.apellido} no participará en ${competencia.nombre}.`
+        mensaje: `${usuario.nombre} ${usuario.apellido} no participará en ${competencia.nombre}.`,
+        competencia: competencia._id
       });
     } catch (e) {
       console.error('Error al notificar al delegado', e);

--- a/backend/controllers/notificationsController.js
+++ b/backend/controllers/notificationsController.js
@@ -5,10 +5,28 @@ exports.obtenerNotificaciones = async (req, res) => {
     const userId = req.user.id;
     const notificaciones = await Notification.find({
       $or: [{ usuario: userId }, { usuario: null }]
-    }).sort({ fecha: -1 });
+    })
+      .sort({ fecha: -1 })
+      .populate('competencia');
     res.json(notificaciones);
   } catch (err) {
     console.error(err);
     res.status(500).json({ msg: 'Error al obtener notificaciones' });
+  }
+};
+
+exports.marcarLeida = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const noti = await Notification.findById(id);
+    if (!noti) return res.status(404).json({ msg: 'No encontrada' });
+    if (noti.usuario && noti.usuario.toString() !== req.user.id)
+      return res.status(403).json({ msg: 'No autorizada' });
+    noti.leida = true;
+    await noti.save();
+    res.json({ msg: 'Notificación actualizada' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: 'Error al actualizar notificación' });
   }
 };

--- a/backend/models/Notification.js
+++ b/backend/models/Notification.js
@@ -2,6 +2,7 @@ const mongoose = require('mongoose');
 
 const notificationSchema = new mongoose.Schema({
   usuario: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  competencia: { type: mongoose.Schema.Types.ObjectId, ref: 'Competencia', default: null },
   mensaje: { type: String, required: true },
   leida: { type: Boolean, default: false },
   fecha: { type: Date, default: Date.now }

--- a/backend/routes/notificationRoutes.js
+++ b/backend/routes/notificationRoutes.js
@@ -4,5 +4,6 @@ const notificationsController = require('../controllers/notificationsController'
 const auth = require('../middleware/authMiddleware');
 
 router.get('/', auth, notificationsController.obtenerNotificaciones);
+router.put('/:id/leida', auth, notificationsController.marcarLeida);
 
 module.exports = router;

--- a/frontend/src/api/notificaciones.js
+++ b/frontend/src/api/notificaciones.js
@@ -6,3 +6,10 @@ export const getNotificaciones = async (token) => {
   });
   return res.data;
 };
+
+export const marcarLeida = async (id, token) => {
+  const res = await api.put(`/notificaciones/${id}/leida`, {}, {
+    headers: { Authorization: token }
+  });
+  return res.data;
+};

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -2,13 +2,14 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useEffect, useState, useRef } from 'react';
 import useAuth from '../store/useAuth';
 import { getNotificaciones } from '../api/notificaciones';
+import useNotifications from '../store/useNotifications';
 import { getMe, updateProfilePicture } from '../api/usuarios';
 
 const Navbar = () => {
   const { user, token, logout } = useAuth();
   const navigate = useNavigate();
   const [profile, setProfile] = useState(null);
-  const [unread, setUnread] = useState(0);
+  const { unread, setUnread } = useNotifications();
   const fileRef = useRef();
 
   useEffect(() => {
@@ -23,7 +24,7 @@ const Navbar = () => {
       }
     };
     if (token) fetchData();
-  }, [token]);
+  }, [token, setUnread]);
 
   const handlePictureChange = async (e) => {
     const file = e.target.files[0];

--- a/frontend/src/pages/Notificaciones.jsx
+++ b/frontend/src/pages/Notificaciones.jsx
@@ -1,9 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import useAuth from '../store/useAuth';
-import { getNotificaciones } from '../api/notificaciones';
+import useNotifications from '../store/useNotifications';
+import { getNotificaciones, marcarLeida } from '../api/notificaciones';
+import { confirmarCompetencia } from '../api/competencias';
 
 const Notificaciones = () => {
   const { token } = useAuth();
+  const { setUnread } = useNotifications();
   const [notificaciones, setNotificaciones] = useState([]);
 
   useEffect(() => {
@@ -11,25 +14,78 @@ const Notificaciones = () => {
       try {
         const data = await getNotificaciones(token);
         setNotificaciones(data);
+        setUnread(data.filter(n => !n.leida).length);
       } catch (err) {
         console.error(err);
         alert('Error al cargar notificaciones');
       }
     };
     fetchData();
-  }, [token]);
+  }, [token, setUnread]);
+
+  const marcarComoLeida = async (id, index) => {
+    try {
+      await marcarLeida(id, token);
+      setNotificaciones(n => {
+        const arr = [...n];
+        arr[index].leida = true;
+        return arr;
+      });
+      setUnread(u => Math.max(u - 1, 0));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const confirmar = async (competenciaId, resp) => {
+    try {
+      await confirmarCompetencia(competenciaId, resp, token);
+      alert('Respuesta registrada');
+    } catch (err) {
+      console.error(err);
+      alert('Error al confirmar');
+    }
+  };
 
   return (
-    <div className="container">
+    <div className="container mt-4">
       <h2 className="mb-4">Notificaciones</h2>
       {notificaciones.length === 0 ? (
         <p>No hay notificaciones.</p>
       ) : (
         <ul className="list-group">
-          {notificaciones.map(n => (
-            <li key={n._id} className="list-group-item">
-              <div>{n.mensaje}</div>
-              <small className="text-muted">{new Date(n.fecha).toLocaleString()}</small>
+          {notificaciones.map((n, idx) => (
+            <li
+              key={n._id}
+              className="list-group-item"
+              onClick={() => !n.leida && marcarComoLeida(n._id, idx)}
+            >
+              <div className={n.leida ? '' : 'fw-bold'}>{n.mensaje}</div>
+              <small className="text-muted">
+                {new Date(n.fecha).toLocaleString()}
+              </small>
+              {n.competencia && (
+                <div className="mt-2">
+                  <button
+                    className="btn btn-sm btn-success me-2"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      confirmar(n.competencia._id, 'SI');
+                    }}
+                  >
+                    Asistir
+                  </button>
+                  <button
+                    className="btn btn-sm btn-danger"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      confirmar(n.competencia._id, 'NO');
+                    }}
+                  >
+                    No asistir
+                  </button>
+                </div>
+              )}
             </li>
           ))}
         </ul>

--- a/frontend/src/store/useNotifications.js
+++ b/frontend/src/store/useNotifications.js
@@ -1,0 +1,8 @@
+import { create } from 'zustand';
+
+const useNotifications = create((set) => ({
+  unread: 0,
+  setUnread: (n) => set({ unread: n })
+}));
+
+export default useNotifications;


### PR DESCRIPTION
## Summary
- add competition references in Notification model
- allow marking notifications as read via new API route
- use zustand store for unread notification count
- show unread notifications in bold and confirm attendance from list
- update navbar to display unread count from store

## Testing
- `npm run lint` *(fails: no output due to env)*

------
https://chatgpt.com/codex/tasks/task_e_685926d1137c8320ae624c0cfde30ab1