### PR TITLE
Add description field to competencias

### DIFF
--- a/backend/controllers/competenciasController.js
+++ b/backend/controllers/competenciasController.js
@@ -5,10 +5,11 @@ const Notification = require('../models/Notification');
 
 exports.crearCompetencia = async (req, res) => {
   try {
-    const { nombre, fecha } = req.body;
+    const { nombre, descripcion, fecha } = req.body;
 
     const competencia = new Competencia({
       nombre,
+      descripcion,
       fecha,
       creador: req.user.id,
       resultados: [],
@@ -94,8 +95,8 @@ exports.agregarResultadosClub = async (req, res) => {
 exports.editarCompetencia = async (req, res) => {
   try {
     const { id } = req.params;
-    const { nombre, fecha } = req.body;
-    await Competencia.findByIdAndUpdate(id, { nombre, fecha });
+    const { nombre, descripcion, fecha } = req.body;
+    await Competencia.findByIdAndUpdate(id, { nombre, descripcion, fecha });
     res.json({ msg: 'Competencia actualizada' });
   } catch (err) {
     console.error(err);

--- a/backend/models/Competencia.js
+++ b/backend/models/Competencia.js
@@ -8,6 +8,7 @@ const resultadoSchema = new mongoose.Schema({
 
 const competenciaSchema = new mongoose.Schema({
   nombre: { type: String, required: true },
+  descripcion: { type: String },
   fecha: { type: Date, required: true },
   creador: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   resultados: [resultadoSchema],

--- a/frontend/src/pages/CrearCompetencia.jsx
+++ b/frontend/src/pages/CrearCompetencia.jsx
@@ -9,6 +9,7 @@ const CrearCompetencia = () => {
 
   const [form, setForm] = useState({
     nombre: '',
+    descripcion: '',
     fecha: ''
   });
 
@@ -34,9 +35,10 @@ const CrearCompetencia = () => {
     <div>
       <h2>Crear Competencia</h2>
       <form onSubmit={handleSubmit}>
-        <input name="nombre" placeholder="Nombre" onChange={handleChange} required />
+        <input name="nombre" placeholder="Titulo" onChange={handleChange} required />
+        <textarea name="descripcion" placeholder="Descripcion" onChange={handleChange} className="form-control my-2" />
         <input type="date" name="fecha" onChange={handleChange} required />
-        <button type="submit">Guardar</button>
+        <button type="submit">Crear</button>
       </form>
     </div>
   );

--- a/frontend/src/pages/EditarCompetencia.jsx
+++ b/frontend/src/pages/EditarCompetencia.jsx
@@ -8,14 +8,14 @@ const EditarCompetencia = () => {
   const navigate = useNavigate();
   const { id } = useParams();
 
-  const [form, setForm] = useState({ nombre: '', fecha: '' });
+  const [form, setForm] = useState({ nombre: '', descripcion: '', fecha: '' });
 
   useEffect(() => {
     const cargar = async () => {
       const comps = await listarCompetencias(token);
       const comp = comps.find(c => c._id === id);
       if (comp) {
-        setForm({ nombre: comp.nombre, fecha: comp.fecha.substring(0, 10) });
+        setForm({ nombre: comp.nombre, descripcion: comp.descripcion || '', fecha: comp.fecha.substring(0, 10) });
       }
     };
     cargar();
@@ -43,6 +43,7 @@ const EditarCompetencia = () => {
       <h2>Editar Competencia</h2>
       <form onSubmit={handleSubmit}>
         <input name="nombre" value={form.nombre} onChange={handleChange} required />
+        <textarea name="descripcion" value={form.descripcion} onChange={handleChange} className="form-control my-2" />
         <input type="date" name="fecha" value={form.fecha} onChange={handleChange} required />
         <button type="submit">Guardar</button>
       </form>


### PR DESCRIPTION
## Summary
- add `descripcion` to Competencia model
- support description in create and update controllers
- include description field on Competencia creation and editing pages
- rename creation labels to match new requirements

## Testing
- `npm test` (backend)
- `npm run lint` (frontend) *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68592a52546483208d4b58519742e691