### PR TITLE
Fix empty patinador value causing ObjectId cast error

### DIFF
--- a/backend/controllers/competenciasController.js
+++ b/backend/controllers/competenciasController.js
@@ -63,11 +63,17 @@ exports.agregarResultados = async (req, res) => {
     }
 
     const parsedResultados = resultados
-      .map(r => ({
-        ...r,
-        posicion: Number(r.posicion),
-        puntos: Number(r.puntos)
-      }))
+      .map(r => {
+        const res = {
+          ...r,
+          posicion: Number(r.posicion),
+          puntos: Number(r.puntos)
+        };
+        if (!res.patinador) {
+          delete res.patinador;
+        }
+        return res;
+      })
       .filter(r => !isNaN(r.posicion) && !isNaN(r.puntos));
 
     competencia.resultados = parsedResultados;


### PR DESCRIPTION
## Summary
- sanitize competition results before saving

## Testing
- `npm test` in `backend` *(fails: Error: no test specified)*
- `npm test` in `frontend` *(fails: missing script)*
- `npm run lint` in `frontend` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685a809d14108320b34e428a7b4c80a4