### PR TITLE
Add lista de buena fe page

### DIFF
--- a/backend/controllers/competenciasController.js
+++ b/backend/controllers/competenciasController.js
@@ -195,3 +195,41 @@ exports.confirmarParticipacion = async (req, res) => {
     res.status(500).json({ msg: 'Error al confirmar participación' });
   }
 };
+
+exports.obtenerListaBuenaFe = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const competencia = await Competencia.findById(id).populate({
+      path: 'listaBuenaFe',
+      populate: { path: 'patinadoresAsociados' }
+    });
+
+    if (!competencia) {
+      return res.status(404).json({ msg: 'Competencia no encontrada' });
+    }
+
+    const lista = [];
+
+    competencia.listaBuenaFe.forEach(u => {
+      u.patinadoresAsociados.forEach(p => {
+        lista.push({
+          _id: p._id,
+          tipoSeguro: 'SA',
+          numeroCorredor: p.numeroCorredor,
+          apellido: p.apellido,
+          primerNombre: p.primerNombre,
+          segundoNombre: p.segundoNombre,
+          categoria: p.categoria,
+          club: p.club || 'General Rodriguez',
+          fechaNacimiento: p.fechaNacimiento,
+          dni: p.dni
+        });
+      });
+    });
+
+    res.json(lista);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: 'Error al obtener lista de buena fe' });
+  }
+};

--- a/backend/routes/competenciasRoutes.js
+++ b/backend/routes/competenciasRoutes.js
@@ -12,6 +12,7 @@ router.put('/resultados-club', auth, checkRole(['Delegado']), competenciasContro
 router.put('/:id', auth, checkRole(['Delegado']), competenciasController.editarCompetencia);
 router.delete('/:id', auth, checkRole(['Delegado']), competenciasController.eliminarCompetencia);
 router.post('/:id/confirmar', auth, competenciasController.confirmarParticipacion);
+router.get('/:id/lista-buena-fe', auth, competenciasController.obtenerListaBuenaFe);
 
 
 module.exports = router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -27,6 +27,7 @@ import Titulos from './pages/Titulos';
 import NoticiaDetalle from './pages/NoticiaDetalle';
 import ConfirmarCompetencia from './pages/ConfirmarCompetencia';
 import Notificaciones from './pages/Notificaciones';
+import ListaBuenaFe from './pages/ListaBuenaFe';
 const App = () => {
   return (
     <Routes>
@@ -47,6 +48,7 @@ const App = () => {
           <Route path="competencias" element={<Competencias />} />
           <Route path="competencias/editar/:id" element={<EditarCompetencia />} />
           <Route path="competencia/:id" element={<VerCompetencia />} />
+          <Route path="competencias/:id/lista-buena-fe" element={<ListaBuenaFe />} />
           <Route path="competencias/:id/resultados" element={<ResultadosCompetencia />} />
           <Route path="competencias/:id/detalle" element={<ResultadosDetalle />} />
           <Route path="competencias/:id/confirmar" element={<ConfirmarCompetencia />} />

--- a/frontend/src/api/competencias.js
+++ b/frontend/src/api/competencias.js
@@ -51,3 +51,10 @@ export const confirmarCompetencia = async (id, respuesta, token) => {
   });
   return res.data;
 };
+
+export const obtenerListaBuenaFe = async (id, token) => {
+  const res = await api.get(`/competencias/${id}/lista-buena-fe`, {
+    headers: { Authorization: token }
+  });
+  return res.data;
+};

--- a/frontend/src/pages/ListaBuenaFe.jsx
+++ b/frontend/src/pages/ListaBuenaFe.jsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+import useAuth from '../store/useAuth';
+import { obtenerListaBuenaFe } from '../api/competencias';
+import { useParams } from 'react-router-dom';
+
+const ListaBuenaFe = () => {
+  const { token } = useAuth();
+  const { id } = useParams();
+  const [lista, setLista] = useState([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const data = await obtenerListaBuenaFe(id, token);
+        const withSeguro = data.map(p => ({ ...p, tipoSeguro: 'SA' }));
+        setLista(withSeguro);
+      } catch (err) {
+        console.error(err);
+        alert('Error al cargar lista de buena fe');
+      }
+    };
+    fetchData();
+  }, []);
+
+  const handleSeguro = (index, value) => {
+    setLista(l => {
+      const arr = [...l];
+      arr[index].tipoSeguro = value;
+      return arr;
+    });
+  };
+
+  return (
+    <div className="container mt-4">
+      <h2>Lista de Buena Fe</h2>
+      {lista.length === 0 ? (
+        <p>No hay patinadores confirmados aún.</p>
+      ) : (
+        <table className="table table-bordered">
+          <thead>
+            <tr>
+              <th>Seguro</th>
+              <th>N° Patinador</th>
+              <th>Apellido</th>
+              <th>Nombre</th>
+              <th>Segundo Nombre</th>
+              <th>Categoría</th>
+              <th>Club</th>
+              <th>Fecha Nacimiento</th>
+              <th>DNI</th>
+            </tr>
+          </thead>
+          <tbody>
+            {lista.map((p, idx) => (
+              <tr key={p._id}>
+                <td>
+                  <select
+                    value={p.tipoSeguro}
+                    onChange={e => handleSeguro(idx, e.target.value)}
+                  >
+                    <option value="SA">SA</option>
+                    <option value="SD">SD</option>
+                  </select>
+                </td>
+                <td>{p.numeroCorredor || '-'}</td>
+                <td>{p.apellido}</td>
+                <td>{p.primerNombre}</td>
+                <td>{p.segundoNombre}</td>
+                <td>{p.categoria}</td>
+                <td>{p.club}</td>
+                <td>{new Date(p.fechaNacimiento).toLocaleDateString()}</td>
+                <td>{p.dni}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+};
+
+export default ListaBuenaFe;

--- a/frontend/src/pages/VerCompetencia.jsx
+++ b/frontend/src/pages/VerCompetencia.jsx
@@ -30,6 +30,9 @@ const VerCompetencia = () => {
       <button className="btn btn-primary" onClick={() => navigate(`/competencias/${id}/resultados`)}>
         Cargar Resultados
       </button>
+      <button className="btn btn-secondary ms-2" onClick={() => navigate(`/competencias/${id}/lista-buena-fe`)}>
+        Ver Lista Buena Fe
+      </button>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- extend competencia controller with endpoint to fetch lista de buena fe
- expose endpoint from competencia routes
- support new API call on frontend
- add ListaBuenaFe page and route
- allow navigation to the list from competition view

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685aceae9c5883208ba56536069e49c2