### PR TITLE
Add club organizer field and enhance Excel export

### DIFF
--- a/backend/controllers/competenciasController.js
+++ b/backend/controllers/competenciasController.js
@@ -6,12 +6,13 @@ const Notification = require('../models/Notification');
 
 exports.crearCompetencia = async (req, res) => {
   try {
-    const { nombre, descripcion, fecha } = req.body;
+    const { nombre, descripcion, fecha, clubOrganizador } = req.body;
 
     const competencia = new Competencia({
       nombre,
       descripcion,
       fecha,
+      clubOrganizador,
       creador: req.user.id,
       resultados: [],
       resultadosClub: [],
@@ -138,8 +139,8 @@ exports.agregarResultadosClub = async (req, res) => {
 exports.editarCompetencia = async (req, res) => {
   try {
     const { id } = req.params;
-    const { nombre, descripcion, fecha } = req.body;
-    await Competencia.findByIdAndUpdate(id, { nombre, descripcion, fecha });
+    const { nombre, descripcion, fecha, clubOrganizador } = req.body;
+    await Competencia.findByIdAndUpdate(id, { nombre, descripcion, fecha, clubOrganizador });
     res.json({ msg: 'Competencia actualizada' });
   } catch (err) {
     console.error(err);

--- a/backend/models/Competencia.js
+++ b/backend/models/Competencia.js
@@ -13,6 +13,7 @@ const competenciaSchema = new mongoose.Schema({
   nombre: { type: String, required: true },
   descripcion: { type: String },
   fecha: { type: Date, required: true },
+  clubOrganizador: { type: String },
   creador: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   resultados: [resultadoSchema],
   resultadosClub: [{

--- a/frontend/src/pages/CrearCompetencia.jsx
+++ b/frontend/src/pages/CrearCompetencia.jsx
@@ -10,7 +10,8 @@ const CrearCompetencia = () => {
   const [form, setForm] = useState({
     nombre: '',
     descripcion: '',
-    fecha: ''
+    fecha: '',
+    clubOrganizador: ''
   });
 
   const handleChange = e => {
@@ -37,6 +38,12 @@ const CrearCompetencia = () => {
       <form onSubmit={handleSubmit}>
         <input name="nombre" placeholder="Titulo" onChange={handleChange} required />
         <textarea name="descripcion" placeholder="Descripcion" onChange={handleChange} className="form-control my-2" />
+        <input
+          name="clubOrganizador"
+          placeholder="Club organizador"
+          onChange={handleChange}
+          className="form-control my-2"
+        />
         <input type="date" name="fecha" onChange={handleChange} required />
         <button type="submit">Crear</button>
       </form>

--- a/frontend/src/pages/EditarCompetencia.jsx
+++ b/frontend/src/pages/EditarCompetencia.jsx
@@ -8,14 +8,19 @@ const EditarCompetencia = () => {
   const navigate = useNavigate();
   const { id } = useParams();
 
-  const [form, setForm] = useState({ nombre: '', descripcion: '', fecha: '' });
+  const [form, setForm] = useState({ nombre: '', descripcion: '', fecha: '', clubOrganizador: '' });
 
   useEffect(() => {
     const cargar = async () => {
       const comps = await listarCompetencias(token);
       const comp = comps.find(c => c._id === id);
       if (comp) {
-        setForm({ nombre: comp.nombre, descripcion: comp.descripcion || '', fecha: comp.fecha.substring(0, 10) });
+        setForm({
+          nombre: comp.nombre,
+          descripcion: comp.descripcion || '',
+          fecha: comp.fecha.substring(0, 10),
+          clubOrganizador: comp.clubOrganizador || ''
+        });
       }
     };
     cargar();
@@ -44,6 +49,13 @@ const EditarCompetencia = () => {
       <form onSubmit={handleSubmit}>
         <input name="nombre" value={form.nombre} onChange={handleChange} required />
         <textarea name="descripcion" value={form.descripcion} onChange={handleChange} className="form-control my-2" />
+        <input
+          name="clubOrganizador"
+          value={form.clubOrganizador}
+          onChange={handleChange}
+          placeholder="Club organizador"
+          className="form-control my-2"
+        />
         <input type="date" name="fecha" value={form.fecha} onChange={handleChange} required />
         <button type="submit">Guardar</button>
       </form>


### PR DESCRIPTION
## Summary
- store organizing club for each competition
- include the new field in competition creation/editing forms
- load competition details in "Lista Buena Fe" page
- export index numbers and organizing club in the CSV

## Testing
- `npm --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --prefix backend test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685ad41daeb08320b3a5e9bad108ead6