### PR TITLE
Update ranking logic

### DIFF
--- a/frontend/src/pages/RankingGeneral.jsx
+++ b/frontend/src/pages/RankingGeneral.jsx
@@ -8,16 +8,20 @@ const RankingGeneral = () => {
 
   useEffect(() => {
     const fetchData = async () => {
-      const data = await getRankingGeneral(token);
-      setRanking(data);
+      try {
+        const data = await getRankingGeneral(token);
+        setRanking(data);
+      } catch (e) {
+        console.error('Error fetching ranking', e);
+      }
     };
 
     fetchData();
-  }, []);
+  }, [token]);
 
   return (
     <div>
-      <h2>Ranking General de Patinadores</h2>
+      <h2>Ranking General de Clubes</h2>
 
       {ranking.length === 0 ? (
         <p>No hay datos aún.</p>
@@ -26,8 +30,7 @@ const RankingGeneral = () => {
           <thead>
             <tr>
               <th>Posición</th>
-              <th>Patinador</th>
-              <th>Categoría</th>
+              <th>Club</th>
               <th>Puntos Acumulados</th>
             </tr>
           </thead>
@@ -35,8 +38,7 @@ const RankingGeneral = () => {
             {ranking.map((item, index) => (
               <tr key={index}>
                 <td>{index + 1}</td>
-                <td>{item.patinador.primerNombre} {item.patinador.apellido}</td>
-                <td>{item.patinador.categoria}</td>
+                <td>{item.club}</td>
                 <td>{item.puntos}</td>
               </tr>
             ))}

--- a/frontend/src/pages/RankingPorCategorias.jsx
+++ b/frontend/src/pages/RankingPorCategorias.jsx
@@ -8,12 +8,16 @@ const RankingPorCategorias = () => {
 
   useEffect(() => {
     const fetchData = async () => {
-      const data = await getRankingPorCategorias(token);
-      setRankings(data);
+      try {
+        const data = await getRankingPorCategorias(token);
+        setRankings(data);
+      } catch (e) {
+        console.error('Error fetching ranking por categorias', e);
+      }
     };
 
     fetchData();
-  }, []);
+  }, [token]);
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- compute general ranking by club using skater results
- handle results without skaters in category ranking
- show club ranking on the General Ranking page
- improve error handling on ranking pages

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` in `frontend` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685bcfa6e8208320a88458eb7befce45