### PR TITLE
Update dashboard and navbar

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import Dashboard from './pages/Dashboard';
 import Layout from './components/Layout';
 import ProtectedRoute from './components/ProtectedRoute';
 import CrearNoticia from './pages/CrearNoticia';
+import Noticias from './pages/Noticias';
 import MisPatinadores from './pages/MisPatinadores';
 import CrearPatinador from './pages/CrearPatinador';
 import Patinadores from './pages/Patinadores';
@@ -38,6 +39,7 @@ const App = () => {
 
       <Route path="/" element={<ProtectedRoute><Layout /></ProtectedRoute>}>
        <Route path="dashboard" element={<Dashboard />} />
+       <Route path="noticias" element={<Noticias />} />
        <Route path="crear-noticia" element={<CrearNoticia />} />
        <Route path="noticia/:id" element={<NoticiaDetalle />} />
         <Route path="mis-patinadores" element={<MisPatinadores />} />

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -65,9 +65,30 @@ const Navbar = () => {
             <li className="nav-item">
               <Link className="nav-link" to="/dashboard">Dashboard</Link>
             </li>
-            {(isDelegado || isTecnico) && (
+            {(isDelegado || isTecnico) ? (
+              <li className="nav-item dropdown">
+                <a
+                  href="#"
+                  className="nav-link dropdown-toggle"
+                  id="newsDropdown"
+                  role="button"
+                  data-bs-toggle="dropdown"
+                  aria-expanded="false"
+                >
+                  Noticias
+                </a>
+                <ul className="dropdown-menu" aria-labelledby="newsDropdown">
+                  <li>
+                    <Link className="dropdown-item" to="/noticias">Ver Noticias</Link>
+                  </li>
+                  <li>
+                    <Link className="dropdown-item" to="/crear-noticia">Crear Noticia</Link>
+                  </li>
+                </ul>
+              </li>
+            ) : (
               <li className="nav-item">
-                <Link className="nav-link" to="/crear-noticia">Crear Noticia</Link>
+                <Link className="nav-link" to="/noticias">Noticias</Link>
               </li>
             )}
             <li className="nav-item dropdown">

--- a/frontend/src/pages/CrearNoticia.jsx
+++ b/frontend/src/pages/CrearNoticia.jsx
@@ -22,7 +22,7 @@ const CrearNoticia = () => {
     try {
       await crearNoticia(form, token);
       alert("Noticia creada correctamente");
-      navigate('/dashboard');
+      navigate('/noticias');
     } catch (err) {
       console.error(err);
       alert("Error al crear noticia");

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,67 +1,53 @@
 import React, { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
 import useAuth from '../store/useAuth';
-import { getNoticias } from '../api/news';
+import { listarTitulosClub } from '../api/titulos';
+import MisPatinadores from './MisPatinadores';
 
 const Dashboard = () => {
   const { token } = useAuth();
-  const [noticias, setNoticias] = useState([]);
+  const [titulos, setTitulos] = useState([]);
 
   useEffect(() => {
-    const fetchNoticias = async () => {
+    const fetchData = async () => {
       try {
-        const data = await getNoticias(token);
-        setNoticias(data);
+        const data = await listarTitulosClub(token);
+        setTitulos(data);
       } catch (err) {
         console.error(err);
-        alert("Error al cargar noticias");
+        alert('Error al cargar títulos');
       }
     };
-
-    fetchNoticias();
+    fetchData();
   }, [token]);
 
   return (
     <div>
-      <h2 className="mb-4">Últimas Noticias</h2>
-
-      {noticias.length === 0 && <p>No hay noticias disponibles.</p>}
-
-      <div className="row">
-        {noticias.map(noticia => (
-          <div key={noticia._id} className="col-md-6 col-lg-4 mb-4">
-            <div className="card h-100">
-              {noticia.imagen && (
-                <img
-                  src={`http://localhost:5000/uploads/${noticia.imagen}`}
-                  className="card-img-top"
-                  alt="Imagen noticia"
-                  style={{ objectFit: 'cover', height: '200px' }}
-                />
-              )}
-              <div className="card-body d-flex flex-column">
-                <h5 className="card-title">{noticia.titulo}</h5>
+      <div className="row mb-4">
+        {titulos.map(t => (
+          <div key={t._id} className="col-md-4 mb-3">
+            <div className="card bg-dark text-white">
+              <img
+                src="/vite.svg"
+                className="card-img"
+                alt="Título"
+                style={{ objectFit: 'cover', height: '200px' }}
+              />
+              <div className="card-img-overlay d-flex flex-column justify-content-end">
+                <h5 className="card-title">{t.titulo}</h5>
                 <p className="card-text">
-                  {noticia.contenido.length > 120
-                    ? `${noticia.contenido.substring(0, 120)}...`
-                    : noticia.contenido}
+                  {t.torneo}
+                  {t.posicion ? ` - Posición ${t.posicion}` : ''}
                 </p>
-                <div className="mt-auto">
-                  <Link to={`/noticia/${noticia._id}`} className="btn btn-primary">
-                    Más info
-                  </Link>
-                </div>
-              </div>
-              <div className="card-footer">
-                <small className="text-muted">
-                  Por: {noticia.autor.nombre} {noticia.autor.apellido} -{' '}
-                  {new Date(noticia.fecha).toLocaleString()}
-                </small>
+                <p className="card-text">
+                  <small>{new Date(t.fecha).toLocaleDateString()}</small>
+                </p>
               </div>
             </div>
           </div>
         ))}
       </div>
+
+      <MisPatinadores />
     </div>
   );
 };

--- a/frontend/src/pages/Noticias.jsx
+++ b/frontend/src/pages/Noticias.jsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import useAuth from '../store/useAuth';
+import { getNoticias } from '../api/news';
+
+const Noticias = () => {
+  const { token } = useAuth();
+  const [noticias, setNoticias] = useState([]);
+
+  useEffect(() => {
+    const fetchNoticias = async () => {
+      try {
+        const data = await getNoticias(token);
+        setNoticias(data);
+      } catch (err) {
+        console.error(err);
+        alert("Error al cargar noticias");
+      }
+    };
+
+    fetchNoticias();
+  }, [token]);
+
+  return (
+    <div>
+      <h2 className="mb-4">Noticias</h2>
+
+      {noticias.length === 0 && <p>No hay noticias disponibles.</p>}
+
+      <div className="row">
+        {noticias.map(noticia => (
+          <div key={noticia._id} className="col-md-6 col-lg-4 mb-4">
+            <div className="card h-100">
+              {noticia.imagen && (
+                <img
+                  src={`http://localhost:5000/uploads/${noticia.imagen}`}
+                  className="card-img-top"
+                  alt="Imagen noticia"
+                  style={{ objectFit: 'cover', height: '200px' }}
+                />
+              )}
+              <div className="card-body d-flex flex-column">
+                <h5 className="card-title">{noticia.titulo}</h5>
+                <p className="card-text">
+                  {noticia.contenido.length > 120
+                    ? `${noticia.contenido.substring(0, 120)}...`
+                    : noticia.contenido}
+                </p>
+                <div className="mt-auto">
+                  <Link to={`/noticia/${noticia._id}`} className="btn btn-primary">
+                    Más info
+                  </Link>
+                </div>
+              </div>
+              <div className="card-footer">
+                <small className="text-muted">
+                  Por: {noticia.autor.nombre} {noticia.autor.apellido} -{' '}
+                  {new Date(noticia.fecha).toLocaleString()}
+                </small>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Noticias;


### PR DESCRIPTION
## Summary
- create a Noticias page for listing news
- update Dashboard to show club titles and Mis Patinadores
- change redirect after creating news
- add Noticias route
- move news into a dropdown on Navbar

## Testing
- `npm test` in `backend` *(fails: Error no test specified)*
- `npm test` in `frontend` *(fails: missing script)*
- `npm run lint` in `frontend` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c85a6f4488320848e278d436589cf