### PR TITLE
Show trophy images in dashboard carousel

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -29,7 +29,11 @@ const Dashboard = () => {
               <div key={t._id} className={`carousel-item ${idx === 0 ? 'active' : ''}`}>
                 <div className="card bg-dark text-white">
                   <img
-                    src="/vite.svg"
+                    src={
+                      t.imagen
+                        ? `http://localhost:5000/uploads/${t.imagen}`
+                        : '/vite.svg'
+                    }
                     className="card-img"
                     alt="Título"
                     style={{ objectFit: 'cover', height: '200px' }}


### PR DESCRIPTION
## Summary
- display stored trophy/medal image in the dashboard carousel

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_685d1b750eb883209940147acedbc51b