### PR TITLE
Update mis patinadores layout

### DIFF
--- a/frontend/src/pages/MisPatinadores.jsx
+++ b/frontend/src/pages/MisPatinadores.jsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import useAuth from '../store/useAuth';
 import { asociarPatinador, getMisPatinadores } from '../api/patinadores';
+import { listarTitulosIndividuales } from '../api/titulos';
 
 const MisPatinadores = () => {
   const { token } = useAuth();
   const [dni, setDni] = useState('');
   const [patinadores, setPatinadores] = useState([]);
+  const [titulos, setTitulos] = useState([]);
 
   const fetchPatinadores = async () => {
     try {
@@ -17,8 +19,19 @@ const MisPatinadores = () => {
     }
   };
 
+  const fetchTitulos = async () => {
+    try {
+      const data = await listarTitulosIndividuales(token);
+      setTitulos(data);
+    } catch (err) {
+      console.error(err);
+      alert('Error al cargar titulos');
+    }
+  };
+
   useEffect(() => {
     fetchPatinadores();
+    fetchTitulos();
   }, []);
 
   const handleAsociar = async () => {
@@ -36,33 +49,68 @@ const MisPatinadores = () => {
   };
 
   return (
-    <div>
-      <h2>Mis Patinadores</h2>
+    <div className="container my-4">
+      <h2 className="mb-4">Mis Patinadores</h2>
 
       {patinadores.length === 0 && (
-        <div>
-          <p>No tienes patinadores asociados.</p>
-          <input type="text" placeholder="DNI para asociar" value={dni} onChange={e => setDni(e.target.value)} />
-          <button onClick={handleAsociar}>Asociar Patinadores</button>
+        <div className="card p-3">
+          <p className="mb-2">No tienes patinadores asociados.</p>
+          <div className="input-group">
+            <input
+              type="text"
+              className="form-control"
+              placeholder="DNI para asociar"
+              value={dni}
+              onChange={e => setDni(e.target.value)}
+            />
+            <button className="btn btn-primary" onClick={handleAsociar}>
+              Asociar Patinadores
+            </button>
+          </div>
         </div>
       )}
 
       {patinadores.length > 0 && (
-        <>
-          <h3>Patinadores asociados:</h3>
-          <ul>
-            {patinadores.map(p => (
-              <li key={p._id}>
-                <strong>{p.primerNombre} {p.apellido}</strong> - {p.categoria} - {p.club}
-                {p.fotoRostro && (
-                  <div>
-                    <img src={`http://localhost:5000/uploads/${p.fotoRostro}`} alt="Rostro" width={150} />
+        <div className="row">
+          {patinadores.map(p => {
+            const misTitulos = titulos.filter(t => t.patinador?._id === p._id);
+            return (
+              <div key={p._id} className="col-12 mb-4">
+                <div className="card h-100 flex-md-row">
+                  {p.foto && (
+                    <img
+                      src={`http://localhost:5000/uploads/${p.foto}`}
+                      alt="Foto"
+                      className="img-fluid rounded-start"
+                      style={{ width: '200px', objectFit: 'cover' }}
+                    />
+                  )}
+                  <div className="card-body">
+                    <h5 className="card-title">
+                      {p.primerNombre} {p.apellido}
+                    </h5>
+                    <p className="card-text mb-1">Categoría: {p.categoria}</p>
+                    <p className="card-text">Club: {p.club}</p>
+                    <h6 className="mt-3">Títulos personales</h6>
+                    <ul className="mb-0">
+                      {misTitulos.length > 0 ? (
+                        misTitulos.map(t => (
+                          <li key={t._id}>
+                            {t.titulo} - {t.torneo} ({
+                              new Date(t.fecha).toLocaleDateString()
+                            })
+                          </li>
+                        ))
+                      ) : (
+                        <li>No posee títulos</li>
+                      )}
+                    </ul>
                   </div>
-                )}
-              </li>
-            ))}
-          </ul>
-        </>
+                </div>
+              </div>
+            );
+          })}
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- show associated skaters as bootstrap cards with full body photo and personal titles
- fetch individual titles to display alongside each skater

## Testing
- `npm --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d1d72368083209a7a2b4ed19ca35a