### PR TITLE
Fix Excel exports

### DIFF
--- a/frontend/src/pages/ListaBuenaFe.jsx
+++ b/frontend/src/pages/ListaBuenaFe.jsx
@@ -61,11 +61,14 @@ const ListaBuenaFe = () => {
       competencia?.clubOrganizador || ''
     ]);
 
+    // Excel en algunos idiomas usa ';' como separador por defecto
     const csvContent = [encabezados, ...filas]
-      .map(row => row.join(','))
+      .map(row => row.join(';'))
       .join('\n');
+    // Agregar BOM para que Excel detecte UTF-8 correctamente
+    const csvWithBom = '\uFEFF' + csvContent;
 
-    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const blob = new Blob([csvWithBom], { type: 'text/csv;charset=utf-8;' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;

--- a/frontend/src/pages/SolicitudSeguro.jsx
+++ b/frontend/src/pages/SolicitudSeguro.jsx
@@ -96,10 +96,13 @@ const SolicitudSeguro = () => {
       p.telefono || '',
       p.tipoLicSeg
     ]);
+    // Algunos Excel utilizan ';' como separador predeterminado
     const csvContent = [encabezados, ...filas]
-      .map(row => row.join(','))
+      .map(row => row.join(';'))
       .join('\n');
-    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    // Incluir BOM para forzar a Excel a reconocer UTF-8
+    const csvWithBom = '\uFEFF' + csvContent;
+    const blob = new Blob([csvWithBom], { type: 'text/csv;charset=utf-8;' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;


### PR DESCRIPTION
## Summary
- fix export in ListaBuenaFe to use semicolon separator and BOM
- fix export in SolicitudSeguro with the same CSV settings

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d972b36208320abaa4bb841454bb3