### PR TITLE
Implement formatted Excel export for LBF

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -20,7 +20,8 @@
     "google-auth-library": "^10.1.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.15.1",
-    "nodemailer": "^7.0.3"
+    "nodemailer": "^7.0.3",
+    "exceljs": "^4.3.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"

--- a/backend/routes/competenciasRoutes.js
+++ b/backend/routes/competenciasRoutes.js
@@ -13,6 +13,7 @@ router.put('/:id', auth, checkRole(['Delegado']), competenciasController.editarC
 router.delete('/:id', auth, checkRole(['Delegado']), competenciasController.eliminarCompetencia);
 router.post('/:id/confirmar', auth, competenciasController.confirmarParticipacion);
 router.get('/:id/lista-buena-fe', auth, competenciasController.obtenerListaBuenaFe);
+router.get('/:id/lista-buena-fe/excel', auth, competenciasController.exportarListaBuenaFeExcel);
 
 
 module.exports = router;

--- a/frontend/src/api/competencias.js
+++ b/frontend/src/api/competencias.js
@@ -58,3 +58,11 @@ export const obtenerListaBuenaFe = async (id, token) => {
   });
   return res.data;
 };
+
+export const descargarListaBuenaFeExcel = async (id, token) => {
+  const res = await api.get(`/competencias/${id}/lista-buena-fe/excel`, {
+    headers: { Authorization: token },
+    responseType: 'blob'
+  });
+  return res.data;
+};

--- a/frontend/src/pages/ListaBuenaFe.jsx
+++ b/frontend/src/pages/ListaBuenaFe.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import useAuth from '../store/useAuth';
-import { obtenerListaBuenaFe, listarCompetencias } from '../api/competencias';
+import { obtenerListaBuenaFe, listarCompetencias, descargarListaBuenaFeExcel } from '../api/competencias';
 import { useParams } from 'react-router-dom';
 
 const ListaBuenaFe = () => {
@@ -36,45 +36,19 @@ const ListaBuenaFe = () => {
     });
   };
 
-  const exportarExcel = () => {
-    const encabezados = [
-      'N°',
-      'Seguro',
-      'N° Patinador',
-      'Nombre Completo',
-      'Categoría',
-      'Club',
-      'Fecha Nacimiento',
-      'DNI',
-      'Club Organizador'
-    ];
-
-    const filas = lista.map((p, index) => [
-      index + 1,
-      p.tipoSeguro,
-      p.numeroCorredor || '-',
-      `${p.apellido} ${p.primerNombre} ${p.segundoNombre || ''}`.trim(),
-      p.categoria,
-      p.club,
-      new Date(p.fechaNacimiento).toLocaleDateString(),
-      p.dni,
-      competencia?.clubOrganizador || ''
-    ]);
-
-    // Excel en algunos idiomas usa ';' como separador por defecto
-    const csvContent = [encabezados, ...filas]
-      .map(row => row.join(';'))
-      .join('\n');
-    // Agregar BOM para que Excel detecte UTF-8 correctamente
-    const csvWithBom = '\uFEFF' + csvContent;
-
-    const blob = new Blob([csvWithBom], { type: 'text/csv;charset=utf-8;' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'lista_buena_fe.csv';
-    a.click();
-    URL.revokeObjectURL(url);
+  const exportarExcel = async () => {
+    try {
+      const blob = await descargarListaBuenaFeExcel(id, token);
+      const url = URL.createObjectURL(new Blob([blob]));
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'lista_buena_fe.xlsx';
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error(err);
+      alert('Error al exportar a Excel');
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- add `exceljs` dependency
- generate formatted LBF spreadsheet in backend
- expose new route `/api/competencias/:id/lista-buena-fe/excel`
- add frontend helper and hook up download button

## Testing
- `npm test` in backend *(fails: no test specified)*
- `npm test` in frontend *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685da2df4bd88320a0645a9cf2556c44