### PR TITLE
Fix profile picture display in navbar

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -200,7 +200,11 @@ const Navbar = () => {
               >
                 {profile?.picture ? (
                   <img
-                    src={`http://localhost:5000/uploads/${profile.picture}`}
+                    src={
+                      profile.picture.startsWith('http')
+                        ? profile.picture
+                        : `http://localhost:5000/uploads/${profile.picture}`
+                    }
                     alt="Perfil"
                     className="rounded-circle"
                     width="32"


### PR DESCRIPTION
## Summary
- handle external picture URLs in `Navbar` so Google profile images show correctly

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e6f76bf688320be4a24bf1bc5dab4