### PR TITLE
Fix club default value in ranking

### DIFF
--- a/backend/controllers/competenciasController.js
+++ b/backend/controllers/competenciasController.js
@@ -88,10 +88,10 @@ exports.agregarResultados = async (req, res) => {
     const acumulado = {};
 
     parsedResultados.forEach(res => {
-      let club = 'Sin club';
+      let club = 'General Rodriguez';
       if (res.patinador) {
         const pat = patinadores.find(p => p._id.toString() === res.patinador);
-        club = pat?.club || 'Sin club';
+        club = pat?.club || 'General Rodriguez';
       } else if (res.club) {
         club = res.club;
       }

--- a/backend/controllers/rankingController.js
+++ b/backend/controllers/rankingController.js
@@ -11,7 +11,7 @@ exports.getRankingGeneral = async (req, res) => {
 
     competencias.forEach(comp => {
       comp.resultados.forEach(res => {
-        const club = res.patinador ? (res.patinador.club || 'Sin club') : (res.club || 'Sin club');
+        const club = res.patinador ? (res.patinador.club || 'General Rodriguez') : (res.club || 'General Rodriguez');
         const puntos = Number(res.puntos) || 0;
         acumulado[club] = (acumulado[club] || 0) + puntos;
       });


### PR DESCRIPTION
## Summary
- update fallback for missing club in ranking and results processing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685ef778132c8320800403a057a919e8