### PR TITLE
Add role-specific navigation

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -32,6 +32,8 @@ import ConfirmarCompetencia from './pages/ConfirmarCompetencia';
 import Notificaciones from './pages/Notificaciones';
 import ListaBuenaFe from './pages/ListaBuenaFe';
 import SolicitudSeguro from './pages/SolicitudSeguro';
+import CrearInforme from './pages/CrearInforme';
+import RegistrarAsistencia from './pages/RegistrarAsistencia';
 const App = () => {
   return (
     <Routes>
@@ -67,6 +69,8 @@ const App = () => {
   <Route path="titulos/club/editar/:id" element={<EditarTituloClub />} />
   <Route path="solicitud-seguro" element={<SolicitudSeguro />} />
   <Route path="notificaciones" element={<Notificaciones />} />
+  <Route path="crear-informe" element={<CrearInforme />} />
+  <Route path="registrar-asistencia" element={<RegistrarAsistencia />} />
       </Route>
     </Routes>
   );

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -107,6 +107,16 @@ const Navbar = () => {
                 <li><Link className="dropdown-item" to="/ranking-categorias">Ranking por Categorías</Link></li>
               </ul>
             </li>
+            {isTecnico && (
+              <>
+                <li className="nav-item">
+                  <Link className="nav-link" to="/crear-informe">Crear Informe</Link>
+                </li>
+                <li className="nav-item">
+                  <Link className="nav-link" to="/registrar-asistencia">Registrar Asistencia</Link>
+                </li>
+              </>
+            )}
             {isDelegado ? (
               <li className="nav-item dropdown">
                 <a
@@ -130,42 +140,52 @@ const Navbar = () => {
                 <Link className="nav-link" to="/mis-patinadores">Mis Patinadores</Link>
               </li>
             )}
-            <li className="nav-item dropdown">
-              <a
-                href="#"
-                className="nav-link dropdown-toggle"
-                id="competenciasDropdown"
-                role="button"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                Competencias
-              </a>
-              <ul className="dropdown-menu" aria-labelledby="competenciasDropdown">
-                <li><Link className="dropdown-item" to="/competencias">Competencias</Link></li>
-                <li><Link className="dropdown-item" to="/crear-competencia">Crear Competencia</Link></li>
-              </ul>
-            </li>
-            <li className="nav-item dropdown">
-              <a
-                href="#"
-                className="nav-link dropdown-toggle"
-                id="titulosDropdown"
-                role="button"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                Títulos
-              </a>
-              <ul className="dropdown-menu" aria-labelledby="titulosDropdown">
-                <li><Link className="dropdown-item" to="/titulos">Ver Títulos</Link></li>
-                <li><Link className="dropdown-item" to="/titulos/individual">Nuevo Título Individual</Link></li>
-                <li><Link className="dropdown-item" to="/titulos/club">Nuevo Título Club</Link></li>
-              </ul>
-            </li>
-            <li className="nav-item">
-              <Link className="nav-link" to="/solicitud-seguro">Solicitud Seguro</Link>
-            </li>
+            {isDelegado && (
+              <li className="nav-item dropdown">
+                <a
+                  href="#"
+                  className="nav-link dropdown-toggle"
+                  id="competenciasDropdown"
+                  role="button"
+                  data-bs-toggle="dropdown"
+                  aria-expanded="false"
+                >
+                  Competencias
+                </a>
+                <ul className="dropdown-menu" aria-labelledby="competenciasDropdown">
+                  <li><Link className="dropdown-item" to="/competencias">Competencias</Link></li>
+                  <li><Link className="dropdown-item" to="/crear-competencia">Crear Competencia</Link></li>
+                </ul>
+              </li>
+            )}
+            {isDelegado ? (
+              <li className="nav-item dropdown">
+                <a
+                  href="#"
+                  className="nav-link dropdown-toggle"
+                  id="titulosDropdown"
+                  role="button"
+                  data-bs-toggle="dropdown"
+                  aria-expanded="false"
+                >
+                  Títulos
+                </a>
+                <ul className="dropdown-menu" aria-labelledby="titulosDropdown">
+                  <li><Link className="dropdown-item" to="/titulos">Ver Títulos</Link></li>
+                  <li><Link className="dropdown-item" to="/titulos/individual">Nuevo Título Individual</Link></li>
+                  <li><Link className="dropdown-item" to="/titulos/club">Nuevo Título Club</Link></li>
+                </ul>
+              </li>
+            ) : (
+              <li className="nav-item">
+                <Link className="nav-link" to="/titulos">Títulos</Link>
+              </li>
+            )}
+            {isDelegado && (
+              <li className="nav-item">
+                <Link className="nav-link" to="/solicitud-seguro">Solicitud Seguro</Link>
+              </li>
+            )}
           </ul>
           <div className="d-flex align-items-center">
             <button

--- a/frontend/src/pages/CrearInforme.jsx
+++ b/frontend/src/pages/CrearInforme.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const CrearInforme = () => (
+  <div className="container my-4">
+    <h2>Crear Informe</h2>
+    <p>P\u00e1gina en construcci\u00f3n.</p>
+  </div>
+);
+
+export default CrearInforme;

--- a/frontend/src/pages/RegistrarAsistencia.jsx
+++ b/frontend/src/pages/RegistrarAsistencia.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const RegistrarAsistencia = () => (
+  <div className="container my-4">
+    <h2>Registrar Asistencia</h2>
+    <p>P\u00e1gina en construcci\u00f3n.</p>
+  </div>
+);
+
+export default RegistrarAsistencia;


### PR DESCRIPTION
## Summary
- show tech-only links for creating reports and attendance records
- restrict competition and insurance menus to delegates
- display title creation options only to delegates
- add placeholder pages for `CrearInforme` and `RegistrarAsistencia`
- wire new pages into the router

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685f37d8faec83208775c25388615aa4