### PR TITLE
Enable baja update for all skaters

### DIFF
--- a/backend/models/Competencia.js
+++ b/backend/models/Competencia.js
@@ -25,6 +25,7 @@ const competenciaSchema = new mongoose.Schema({
     patinador: { type: mongoose.Schema.Types.ObjectId, ref: 'Patinador' },
     baja: { type: Boolean, default: false }
   }],
+  bajas: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Patinador' }],
   padronSeguros: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }]
 });
 


### PR DESCRIPTION
## Summary
- allow marking skaters from initial list as dropped
- track dropped skaters in new `bajas` array
- include baja state when exporting or listing skaters

## Testing
- `npm run lint` *(fails: React Hook dependency warnings)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6864a9087704832087e614beb5acf7be