### PR TITLE
Add skater address to insurance export

### DIFF
--- a/frontend/src/pages/SolicitudSeguro.jsx
+++ b/frontend/src/pages/SolicitudSeguro.jsx
@@ -188,7 +188,7 @@ const SolicitudSeguro = () => {
     };
 
     lista.forEach(p => {
-      ws.addRow([
+      const row = ws.addRow([
         '',
         '',
         '',
@@ -204,13 +204,16 @@ const SolicitudSeguro = () => {
         DEFAULTS.nacionalidad,
         p.club || DEFAULTS.club,
         DEFAULTS.funcion,
-        '',
+        p.direccion || '',
         DEFAULTS.codigoPostal,
         DEFAULTS.localidad,
         DEFAULTS.provincia,
         p.telefono || '',
         p.tipoLicSeg
       ]);
+      row.eachCell({ includeEmpty: true }, cell => {
+        cell.alignment = { vertical: 'middle', horizontal: 'center' };
+      });
     });
 
     const buffer = await workbook.xlsx.writeBuffer();


### PR DESCRIPTION
## Summary
- export skater address in `SolicitudSeguro` Excel sheet
- center all row data horizontally and vertically

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6865471dd3d8832086da8099ba9e5116