### PR TITLE
Fix export template formatting

### DIFF
--- a/frontend/src/pages/SolicitudSeguro.jsx
+++ b/frontend/src/pages/SolicitudSeguro.jsx
@@ -86,6 +86,8 @@ const SolicitudSeguro = () => {
       { width: 18.67 }
     ];
 
+    ws.getRow(2).height = 43.2;
+
     ws.mergeCells('A2:F2');
     ws.getCell('A2').value = 'NO COMPLETAR ESTAS COLUMNAS';
     ws.getCell('A2').alignment = { vertical: 'middle', horizontal: 'center' };
@@ -192,7 +194,7 @@ const SolicitudSeguro = () => {
         '',
         '',
         '',
-        p.dni,
+        '',
         '',
         '',
         p.dni,


### PR DESCRIPTION
## Summary
- set row height 2 to 43.2 in Excel export
- leave column D blank for generated rows

## Testing
- `npm run lint` (frontend)
- `npm test` (frontend, expected failure)
- `npm test` (backend, expected failure)


------
https://chatgpt.com/codex/tasks/task_e_68654aef511c832090b9fc871bada698