### PR TITLE
Update layout for Mis Patinadores page

### DIFF
--- a/frontend/src/pages/MisPatinadores.jsx
+++ b/frontend/src/pages/MisPatinadores.jsx
@@ -71,18 +71,21 @@ const MisPatinadores = () => {
       )}
 
       {patinadores.length > 0 && (
-        <div className="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
+        <div className="row row-cols-1 g-4">
           {patinadores.map(p => {
             const misTitulos = titulos.filter(t => t.patinador?._id === p._id);
             return (
               <div key={p._id} className="col">
-                <div className="card h-100">
+                <div
+                  className="card flex-md-row"
+                  style={{ minHeight: '80vh' }}
+                >
                   {p.foto && (
                     <img
                       src={`http://localhost:5000/uploads/${p.foto}`}
                       alt="Foto"
-                      className="card-img-top"
-                      style={{ objectFit: 'cover', height: '200px' }}
+                      className="m-3"
+                      style={{ objectFit: 'cover', height: '80vh' }}
                     />
                   )}
                   <div className="card-body d-flex flex-column">


### PR DESCRIPTION
## Summary
- adjust Mis Patinadores layout so the skater's image appears on the left at 80vh height and information on the right

## Testing
- `npm run lint` within `frontend`
- `npm test` within `backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6866679ced58832082030aeda1b0fa87