### PR TITLE
Remove old title carousel and enhance photo carousel

### DIFF
--- a/frontend/src/components/FotoCarousel.jsx
+++ b/frontend/src/components/FotoCarousel.jsx
@@ -3,6 +3,20 @@ import Slider from 'react-slick';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 
+const PrevArrow = ({ onClick }) => (
+  <button type="button" className="carousel-control-prev" onClick={onClick}>
+    <span className="carousel-control-prev-icon" aria-hidden="true" />
+    <span className="visually-hidden">Anterior</span>
+  </button>
+);
+
+const NextArrow = ({ onClick }) => (
+  <button type="button" className="carousel-control-next" onClick={onClick}>
+    <span className="carousel-control-next-icon" aria-hidden="true" />
+    <span className="visually-hidden">Siguiente</span>
+  </button>
+);
+
 const FotoCarousel = ({ fotos }) => {
   const settings = {
     centerMode: true,
@@ -10,10 +24,12 @@ const FotoCarousel = ({ fotos }) => {
     slidesToShow: Math.min(3, fotos.length),
     infinite: true,
     arrows: true,
+    prevArrow: <PrevArrow />,
+    nextArrow: <NextArrow />,
   };
 
   return (
-    <Slider {...settings} className="photo-carousel">
+    <Slider {...settings} className="photo-carousel carousel slide">
       {fotos.map((f) => (
         <div key={f._id}>
           <img

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,20 +1,16 @@
 import React, { useEffect, useState } from 'react';
 import useAuth from '../store/useAuth';
-import { listarTitulosClub } from '../api/titulos';
 import { getFotos } from '../api/fotos';
 import MisPatinadores from './MisPatinadores';
 import FotoCarousel from '../components/FotoCarousel';
 
 const Dashboard = () => {
   const { token } = useAuth();
-  const [titulos, setTitulos] = useState([]);
   const [fotos, setFotos] = useState([]);
 
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const data = await listarTitulosClub(token);
-        setTitulos(data);
         const imgs = await getFotos(token);
         setFotos(imgs);
       } catch (err) {
@@ -32,56 +28,6 @@ const Dashboard = () => {
           <FotoCarousel fotos={fotos} />
         </div>
       )}
-      <div className="mb-4">
-        <div id="titulosCarousel" className="carousel slide" data-bs-ride="carousel">
-          <div className="carousel-inner">
-            {titulos.map((t, idx) => (
-              <div key={t._id} className={`carousel-item ${idx === 0 ? 'active' : ''}`}>
-                <div className="card bg-dark text-white">
-                  <img
-                    src={
-                      t.imagen
-                        ? `http://localhost:5000/uploads/${t.imagen}`
-                        : '/vite.svg'
-                    }
-                    className="card-img"
-                    alt="Título"
-                    style={{ objectFit: 'cover', height: '200px' }}
-                  />
-                  <div className="card-img-overlay d-flex flex-column justify-content-end">
-                    <h5 className="card-title">{t.titulo}</h5>
-                    <p className="card-text">
-                      {t.torneo}
-                      {t.posicion ? ` - Posición ${t.posicion}` : ''}
-                    </p>
-                    <p className="card-text">
-                      <small>{new Date(t.fecha).toLocaleDateString()}</small>
-                    </p>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-          <button
-            className="carousel-control-prev"
-            type="button"
-            data-bs-target="#titulosCarousel"
-            data-bs-slide="prev"
-          >
-            <span className="carousel-control-prev-icon" aria-hidden="true" />
-            <span className="visually-hidden">Anterior</span>
-          </button>
-          <button
-            className="carousel-control-next"
-            type="button"
-            data-bs-target="#titulosCarousel"
-            data-bs-slide="next"
-          >
-            <span className="carousel-control-next-icon" aria-hidden="true" />
-            <span className="visually-hidden">Siguiente</span>
-          </button>
-        </div>
-      </div>
 
       <MisPatinadores />
     </div>


### PR DESCRIPTION
## Summary
- remove title-based carousel from Dashboard
- style photo carousel with Bootstrap arrows
- remove unused title fetching logic

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6866713f227483209c04fe51ebb53e8a