### PR TITLE
Implement per-user read status for notifications

### DIFF
--- a/backend/models/Notification.js
+++ b/backend/models/Notification.js
@@ -4,7 +4,7 @@ const notificationSchema = new mongoose.Schema({
   usuario: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
   competencia: { type: mongoose.Schema.Types.ObjectId, ref: 'Competencia', default: null },
   mensaje: { type: String, required: true },
-  leida: { type: Boolean, default: false },
+  leidosPor: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User', default: [] }],
   fecha: { type: Date, default: Date.now }
 });
 


### PR DESCRIPTION
## Summary
- track user read status with `leidosPor` array in Notification model
- compute `leida` per user when fetching notifications
- update read logic to store user id instead of global flag

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` in `frontend` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68673947ad088320bea810fbd50d8cbb