### PR TITLE
Implement attendance management for technicians

### DIFF
--- a/backend/controllers/asistenciasController.js
+++ b/backend/controllers/asistenciasController.js
@@ -1,0 +1,85 @@
+const Asistencia = require('../models/Asistencia');
+const Patinador = require('../models/Patinador');
+
+// Helper to apply increments/decrements to patinador asistencias
+const applyCounts = async (detalles, fecha, factor) => {
+  const year = new Date(fecha).getFullYear();
+  for (const det of detalles) {
+    const pat = await Patinador.findById(det.patinador);
+    if (!pat) continue;
+    let reg = pat.asistencias.find(a => a.year === year);
+    if (!reg) {
+      reg = { year, presentes: 0, ausentes: 0 };
+      pat.asistencias.push(reg);
+    }
+    if (det.presente) {
+      reg.presentes += factor;
+    } else {
+      reg.ausentes += factor;
+    }
+    await pat.save();
+  }
+};
+
+exports.crearAsistencia = async (req, res) => {
+  try {
+    const { fecha = Date.now(), detalles } = req.body;
+    const asistencia = new Asistencia({ fecha, tecnico: req.user.id, detalles });
+    await asistencia.save();
+    await applyCounts(detalles, fecha, 1);
+    res.json({ msg: 'Asistencia registrada' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: 'Error al registrar asistencia' });
+  }
+};
+
+exports.obtenerAsistencias = async (req, res) => {
+  try {
+    const asistencias = await Asistencia.find({ tecnico: req.user.id }).populate('detalles.patinador');
+    res.json(asistencias);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: 'Error al obtener asistencias' });
+  }
+};
+
+exports.obtenerAsistencia = async (req, res) => {
+  try {
+    const asistencia = await Asistencia.findOne({ _id: req.params.id, tecnico: req.user.id }).populate('detalles.patinador');
+    if (!asistencia) return res.status(404).json({ msg: 'Asistencia no encontrada' });
+    res.json(asistencia);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: 'Error al obtener asistencia' });
+  }
+};
+
+exports.actualizarAsistencia = async (req, res) => {
+  try {
+    const { fecha, detalles } = req.body;
+    const asistencia = await Asistencia.findOne({ _id: req.params.id, tecnico: req.user.id });
+    if (!asistencia) return res.status(404).json({ msg: 'Asistencia no encontrada' });
+    await applyCounts(asistencia.detalles, asistencia.fecha, -1); // remove previous counts
+    asistencia.fecha = fecha;
+    asistencia.detalles = detalles;
+    await asistencia.save();
+    await applyCounts(detalles, fecha, 1);
+    res.json({ msg: 'Asistencia actualizada' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: 'Error al actualizar asistencia' });
+  }
+};
+
+exports.eliminarAsistencia = async (req, res) => {
+  try {
+    const asistencia = await Asistencia.findOneAndDelete({ _id: req.params.id, tecnico: req.user.id });
+    if (!asistencia) return res.status(404).json({ msg: 'Asistencia no encontrada' });
+    await applyCounts(asistencia.detalles, asistencia.fecha, -1);
+    res.json({ msg: 'Asistencia eliminada' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: 'Error al eliminar asistencia' });
+  }
+};

--- a/backend/models/Asistencia.js
+++ b/backend/models/Asistencia.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose');
+
+const detalleSchema = new mongoose.Schema({
+  patinador: { type: mongoose.Schema.Types.ObjectId, ref: 'Patinador', required: true },
+  presente: { type: Boolean, required: true }
+});
+
+const asistenciaSchema = new mongoose.Schema({
+  fecha: { type: Date, default: Date.now },
+  tecnico: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  detalles: [detalleSchema]
+});
+
+module.exports = mongoose.model('Asistencia', asistenciaSchema);

--- a/backend/models/Patinador.js
+++ b/backend/models/Patinador.js
@@ -18,7 +18,12 @@ const patinadorSchema = new mongoose.Schema({
   numeroCorredor: { type: Number },
   categoria: { type: String },
   foto: { type: String },
-  fotoRostro: { type: String }
+  fotoRostro: { type: String },
+  asistencias: [{
+    year: { type: Number },
+    presentes: { type: Number, default: 0 },
+    ausentes: { type: Number, default: 0 }
+  }]
 });
 
 module.exports = mongoose.model('Patinador', patinadorSchema);

--- a/backend/routes/asistenciasRoutes.js
+++ b/backend/routes/asistenciasRoutes.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const router = express.Router();
+const asistenciasController = require('../controllers/asistenciasController');
+const auth = require('../middleware/authMiddleware');
+const checkRole = require('../middleware/roleMiddleware');
+
+router.post('/', auth, checkRole(['Tecnico']), asistenciasController.crearAsistencia);
+router.get('/', auth, checkRole(['Tecnico']), asistenciasController.obtenerAsistencias);
+router.get('/:id', auth, checkRole(['Tecnico']), asistenciasController.obtenerAsistencia);
+router.put('/:id', auth, checkRole(['Tecnico']), asistenciasController.actualizarAsistencia);
+router.delete('/:id', auth, checkRole(['Tecnico']), asistenciasController.eliminarAsistencia);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -24,6 +24,7 @@ app.use('/api/usuarios', require('./routes/userRoutes'));
 app.use('/api/seguros', require('./routes/segurosRoutes'));
 app.use('/api/informes', require('./routes/informesRoutes'));
 app.use('/api/fotos', require('./routes/photoRoutes'));
+app.use('/api/asistencias', require('./routes/asistenciasRoutes'));
 
 
 

--- a/frontend/src/api/asistencias.js
+++ b/frontend/src/api/asistencias.js
@@ -1,0 +1,26 @@
+import api from './api';
+
+export const crearAsistencia = async (data, token) => {
+  const res = await api.post('/asistencias', data, { headers: { Authorization: token } });
+  return res.data;
+};
+
+export const listarAsistencias = async (token) => {
+  const res = await api.get('/asistencias', { headers: { Authorization: token } });
+  return res.data;
+};
+
+export const obtenerAsistencia = async (id, token) => {
+  const res = await api.get(`/asistencias/${id}`, { headers: { Authorization: token } });
+  return res.data;
+};
+
+export const actualizarAsistencia = async (id, data, token) => {
+  const res = await api.put(`/asistencias/${id}`, data, { headers: { Authorization: token } });
+  return res.data;
+};
+
+export const eliminarAsistencia = async (id, token) => {
+  const res = await api.delete(`/asistencias/${id}`, { headers: { Authorization: token } });
+  return res.data;
+};

--- a/frontend/src/pages/RegistrarAsistencia.jsx
+++ b/frontend/src/pages/RegistrarAsistencia.jsx
@@ -1,10 +1,149 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import useAuth from '../store/useAuth';
+import { getTodosLosPatinadores } from '../api/gestionPatinadores';
+import {
+  crearAsistencia,
+  listarAsistencias,
+  actualizarAsistencia,
+  eliminarAsistencia,
+  obtenerAsistencia
+} from '../api/asistencias';
 
-const RegistrarAsistencia = () => (
-  <div className="container my-4">
-    <h2>Registrar Asistencia</h2>
-    <p>P\u00e1gina en construcci\u00f3n.</p>
-  </div>
-);
+const RegistrarAsistencia = () => {
+  const { token } = useAuth();
+  const [asistencias, setAsistencias] = useState([]);
+  const [patinadores, setPatinadores] = useState([]);
+  const [detalles, setDetalles] = useState([]);
+  const [fecha, setFecha] = useState('');
+  const [editId, setEditId] = useState(null);
+  const [modoFormulario, setModoFormulario] = useState(false);
+
+  const cargarAsistencias = async () => {
+    try {
+      const data = await listarAsistencias(token);
+      setAsistencias(data);
+    } catch (err) {
+      console.error(err);
+      alert('Error al obtener asistencias');
+    }
+  };
+
+  useEffect(() => {
+    cargarAsistencias();
+  }, [token]);
+
+  const iniciarCrear = async () => {
+    const pats = await getTodosLosPatinadores(token);
+    setPatinadores(pats);
+    setDetalles(pats.map(p => ({ patinador: p._id, presente: true })));
+    setFecha(new Date().toISOString().substring(0,10));
+    setEditId(null);
+    setModoFormulario(true);
+  };
+
+  const handleCheck = (index, presente) => {
+    setDetalles(prev => {
+      const arr = [...prev];
+      arr[index].presente = presente;
+      return arr;
+    });
+  };
+
+  const handleGuardar = async () => {
+    try {
+      const payload = { fecha, detalles };
+      if (editId) {
+        await actualizarAsistencia(editId, payload, token);
+      } else {
+        await crearAsistencia(payload, token);
+      }
+      setModoFormulario(false);
+      cargarAsistencias();
+    } catch (err) {
+      console.error(err);
+      alert('Error al guardar asistencia');
+    }
+  };
+
+  const handleEditar = async (id) => {
+    try {
+      const data = await obtenerAsistencia(id, token);
+      setPatinadores(data.detalles.map(d => d.patinador));
+      setDetalles(data.detalles.map(d => ({ patinador: d.patinador._id, presente: d.presente })));
+      setFecha(data.fecha.substring(0,10));
+      setEditId(id);
+      setModoFormulario(true);
+    } catch (err) {
+      console.error(err);
+      alert('Error al cargar asistencia');
+    }
+  };
+
+  const handleEliminar = async (id) => {
+    if (!window.confirm('¿Eliminar asistencia?')) return;
+    try {
+      await eliminarAsistencia(id, token);
+      cargarAsistencias();
+    } catch (err) {
+      console.error(err);
+      alert('Error al eliminar asistencia');
+    }
+  };
+
+  if (modoFormulario) {
+    return (
+      <div className="container my-4">
+        <h2>{editId ? 'Editar Entrenamiento' : 'Nuevo Entrenamiento'}</h2>
+        <div className="mb-3">
+          <input type="date" className="form-control" value={fecha} onChange={e => setFecha(e.target.value)} />
+        </div>
+        <div className="table-responsive">
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Patinador</th>
+                <th>Presente</th>
+                <th>Ausente</th>
+              </tr>
+            </thead>
+            <tbody>
+              {patinadores.map((p, idx) => (
+                <tr key={p._id}>
+                  <td>{p.primerNombre} {p.apellido}</td>
+                  <td>
+                    <input type="radio" name={`estado-${idx}`} checked={detalles[idx].presente} onChange={() => handleCheck(idx, true)} />
+                  </td>
+                  <td>
+                    <input type="radio" name={`estado-${idx}`} checked={!detalles[idx].presente} onChange={() => handleCheck(idx, false)} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <button className="btn btn-primary me-2" onClick={handleGuardar}>Guardar</button>
+        <button className="btn btn-secondary" onClick={() => setModoFormulario(false)}>Cancelar</button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container my-4">
+      <h2>Registrar Asistencia</h2>
+      <button className="btn btn-primary mb-3" onClick={iniciarCrear}>Crear Entrenamiento</button>
+      <ul className="list-group">
+        {asistencias.map(a => (
+          <li key={a._id} className="list-group-item d-flex justify-content-between align-items-center">
+            {new Date(a.fecha).toLocaleDateString()}
+            <div>
+              <button className="btn btn-sm btn-outline-primary me-2" onClick={() => handleEditar(a._id)}>Ver/Editar</button>
+              <button className="btn btn-sm btn-outline-danger" onClick={() => handleEliminar(a._id)}>Eliminar</button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
 
 export default RegistrarAsistencia;


### PR DESCRIPTION
## Summary
- add attendance model
- track attendance counts per patinador
- create controller and routes for attendance CRUD
- expose attendance endpoints in the server
- provide attendance API helpers for the frontend
- implement RegistrarAsistencia page

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68673cf1bfc08320b93bd76f97e87d73