### PR TITLE
Fix patinador listing permissions

### DIFF
--- a/backend/routes/gestionPatinadoresRoutes.js
+++ b/backend/routes/gestionPatinadoresRoutes.js
@@ -8,7 +8,8 @@ const validator = require('../middleware/validaeDatosMiddleware')
 
 // Solo Delegados pueden crear patinadores
 router.post('/', auth, checkRole(['Delegado']), uploadMultiple, controller.crearPatinador);
-router.get('/', auth, checkRole(['Delegado']), controller.getTodosLosPatinadores);
+// Delegados y Tecnicos pueden consultar patinadores
+router.get('/', auth, checkRole(['Delegado', 'Tecnico']), controller.getTodosLosPatinadores);
 router.delete('/:id', auth, checkRole(['Delegado']), controller.eliminarPatinador);
 router.put('/:id', auth, checkRole(['Delegado']), uploadMultiple, controller.editarPatinador);
 


### PR DESCRIPTION
## Summary
- allow Tecnico users to view the list of patinadores

## Testing
- `npm test` (fails: no test specified)
- `npm run lint` (fails: cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_686741a4ce248320a576f900e6ecf741