### PR TITLE
Avoid duplicate signups in insurance list

### DIFF
--- a/frontend/src/pages/SolicitudSeguro.jsx
+++ b/frontend/src/pages/SolicitudSeguro.jsx
@@ -41,6 +41,10 @@ const SolicitudSeguro = () => {
 
   const agregar = () => {
     if (!seleccionado) return;
+    if (lista.some(p => p._id === seleccionado)) {
+      alert('El patinador ya está en la lista');
+      return;
+    }
     const pat = patinadores.find(p => p._id === seleccionado);
     if (!pat) return;
     setLista(l => [...l, { ...pat, tipoLicSeg: tipo }]);


### PR DESCRIPTION
## Summary
- prevent repeated skater registrations in insurance request list

## Testing
- `npm run lint` (fails: cannot find `@eslint/js`)
- `npm test` in backend (fails: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_6867cbbab8dc8320891289b65d1c419f