### PR TITLE
Add external skaters to category rankings

### DIFF
--- a/backend/controllers/rankingController.js
+++ b/backend/controllers/rankingController.js
@@ -33,27 +33,28 @@ exports.getRankingPorCategorias = async (req, res) => {
   try {
     const competencias = await Competencia.find().populate('resultados.patinador');
 
-    // Acumulador general
+    // Acumulador general de puntos por categoria
     const acumulado = {};
 
     competencias.forEach(comp => {
       comp.resultados.forEach(res => {
-        if (!res.patinador) return;
-        const categoria = res.patinador.categoria;
-        const id = res.patinador._id.toString();
+        const categoria = res.patinador ? res.patinador.categoria : res.categoria;
+
+        const key = res.patinador
+          ? res.patinador._id.toString()
+          : `${res.nombre}-${res.club}`;
 
         if (!acumulado[categoria]) {
           acumulado[categoria] = {};
         }
 
-        if (!acumulado[categoria][id]) {
-          acumulado[categoria][id] = {
-            patinador: res.patinador,
-            puntos: 0
-          };
+        if (!acumulado[categoria][key]) {
+          acumulado[categoria][key] = res.patinador
+            ? { patinador: res.patinador, club: res.patinador.club, puntos: 0 }
+            : { nombre: res.nombre, club: res.club, puntos: 0 };
         }
 
-        acumulado[categoria][id].puntos += res.puntos;
+        acumulado[categoria][key].puntos += res.puntos;
       });
     });
 

--- a/frontend/src/pages/RankingPorCategorias.jsx
+++ b/frontend/src/pages/RankingPorCategorias.jsx
@@ -34,6 +34,7 @@ const RankingPorCategorias = () => {
                 <tr>
                   <th>Posición</th>
                   <th>Patinador</th>
+                  <th>Club</th>
                   <th>Puntos Acumulados</th>
                 </tr>
               </thead>
@@ -41,7 +42,12 @@ const RankingPorCategorias = () => {
                 {rankings[categoria].map((item, index) => (
                   <tr key={index}>
                     <td>{index + 1}</td>
-                    <td>{item.patinador.primerNombre} {item.patinador.apellido}</td>
+                    <td>
+                      {item.patinador
+                        ? `${item.patinador.primerNombre} ${item.patinador.apellido}`
+                        : item.nombre}
+                    </td>
+                    <td>{item.patinador ? item.patinador.club : item.club}</td>
                     <td>{item.puntos}</td>
                   </tr>
                 ))}


### PR DESCRIPTION
## Summary
- include manual results when building rankings by category
- show club and name for manual entries in RankingPorCategorias page

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` in frontend *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867d8baeb5083208d645dc346be6d28