### PR TITLE
Add footer component to layout

### DIFF
--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Footer = () => (
+  <footer className="bg-dark text-white py-3 mt-auto">
+    <div className="container text-center">
+      &copy; {new Date().getFullYear()} Federación de Patinaje
+    </div>
+  </footer>
+);
+
+export default Footer;

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import Navbar from './Navbar';
+import Footer from './Footer';
 import { Outlet } from 'react-router-dom';
 
 const Layout = () => {
   return (
-    <div>
+    <div className="d-flex flex-column min-vh-100">
       <Navbar />
-      <div className="container py-4">
+      <div className="container py-4 flex-grow-1">
         <Outlet />
       </div>
+      <Footer />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- create simple `Footer` component
- integrate `Footer` into `Layout` so it's displayed on all pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686916497e7c8320bd649494b90e46b6