### PR TITLE
Add Nosotros page and enhanced footer

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -37,6 +37,7 @@ import CrearInforme from './pages/CrearInforme';
 import VerInformes from './pages/VerInformes';
 import RegistrarAsistencia from './pages/RegistrarAsistencia';
 import CrearNotificacion from './pages/CrearNotificacion';
+import Nosotros from './pages/Nosotros';
 const App = () => {
   return (
     <Routes>
@@ -47,6 +48,7 @@ const App = () => {
       <Route path="/" element={<ProtectedRoute><Layout /></ProtectedRoute>}>
        <Route path="dashboard" element={<Dashboard />} />
        <Route path="noticias" element={<Noticias />} />
+       <Route path="nosotros" element={<Nosotros />} />
        <Route path="crear-noticia" element={<CrearNoticia />} />
        <Route path="crear-notificacion" element={<CrearNotificacion />} />
        <Route path="agregar-foto" element={<AgregarFoto />} />

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -1,9 +1,86 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 const Footer = () => (
-  <footer className="bg-dark text-white py-3 mt-auto">
-    <div className="container text-center">
-      &copy; {new Date().getFullYear()} Federación de Patinaje
+  <footer className="bg-dark text-white mt-auto py-4">
+    <div className="container">
+      <div className="row text-center text-md-start">
+        <div className="col-md-3 mb-3 mb-md-0 border-end">
+          <h5>Reseña</h5>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec vitae
+            mi sit amet dolor tempor efficitur. Sed non pharetra nulla. Aliquam
+            erat volutpat. Curabitur at efficitur nisl, nec lacinia ligula.
+            Integer venenatis sapien at lorem laoreet, vel fringilla. Mauris
+            dictum metus ut libero finibus, quis tempor justo fermentum. Nam
+            consequat.
+          </p>
+        </div>
+        <div className="col-md-3 mb-3 mb-md-0 border-end">
+          <h5>Nosotros</h5>
+          <ul className="list-unstyled">
+            <li>
+              <Link to="/nosotros" className="text-white">
+                Acceso a Nosotros
+              </Link>
+            </li>
+            <li>
+              <Link to="/noticias" className="text-white">
+                Ver Noticias
+              </Link>
+            </li>
+            <li>
+              <Link to="/titulos" className="text-white">
+                Ver Títulos
+              </Link>
+            </li>
+          </ul>
+        </div>
+        <div className="col-md-3 mb-3 mb-md-0 border-end">
+          <h5>Secciones</h5>
+          <ul className="list-unstyled">
+            <li>
+              <Link to="/mis-patinadores" className="text-white">
+                Mis patinadores
+              </Link>
+            </li>
+            <li>
+              <Link to="/informes" className="text-white">
+                Informes
+              </Link>
+            </li>
+            <li>
+              <Link to="/ranking" className="text-white">
+                Ranking por clubes
+              </Link>
+            </li>
+            <li>
+              <Link to="/ranking-categorias" className="text-white">
+                Ranking por categorías
+              </Link>
+            </li>
+          </ul>
+        </div>
+        <div className="col-md-3 mb-3 mb-md-0">
+          <h5>Contacto</h5>
+          <p className="mb-1">Dirección del club</p>
+          <p className="mb-1">Teléfono: 123-456789</p>
+          <div>
+            <a href="#" className="text-white me-2">
+              <i className="bi bi-facebook" />
+            </a>
+            <a href="#" className="text-white me-2">
+              <i className="bi bi-instagram" />
+            </a>
+            <a href="#" className="text-white">
+              <i className="bi bi-twitter" />
+            </a>
+          </div>
+        </div>
+      </div>
+      <div className="text-center mt-3">
+        &copy; {new Date().getFullYear()} Federación de Patinaje
+      </div>
     </div>
   </footer>
 );

--- a/frontend/src/pages/Nosotros.jsx
+++ b/frontend/src/pages/Nosotros.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+const Nosotros = () => (
+  <div className="nosotros">
+    <h2 className="mb-4">Nuestra Historia</h2>
+    <p>
+      Somos un club apasionado por el patinaje que nació de un pequeño grupo de
+      entusiastas. Con el tiempo fuimos creciendo y hoy celebramos numerosos
+      logros deportivos y un fuerte sentido de comunidad. Nuestro objetivo es
+      fomentar la disciplina, el compañerismo y el desarrollo integral de cada
+      patinador.
+    </p>
+    <div className="row mt-4">
+      <div className="col-md-4 mb-3">
+        <img
+          src="https://images.unsplash.com/photo-1503023345310-bd7c1de61c7d"
+          alt="Historia 1"
+          className="img-fluid rounded"
+        />
+      </div>
+      <div className="col-md-4 mb-3">
+        <img
+          src="https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e"
+          alt="Historia 2"
+          className="img-fluid rounded"
+        />
+      </div>
+      <div className="col-md-4 mb-3">
+        <img
+          src="https://images.unsplash.com/photo-1527090496-346715f92429"
+          alt="Historia 3"
+          className="img-fluid rounded"
+        />
+      </div>
+    </div>
+  </div>
+);
+
+export default Nosotros;


### PR DESCRIPTION
## Summary
- add a new `Nosotros` page with club history and photos
- update routes to include `/nosotros`
- redesign footer with sections: Reseña, Nosotros, Secciones and Contacto

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686927464a908320b142012a302aedd8