### PR TITLE
Implement animated wave background

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,6 +9,13 @@
     <title>Vite + React</title>
   </head>
   <body>
+    <div id="wave-container">
+      <svg viewBox="0 0 200 100" preserveAspectRatio="none">
+        <path d="M0 50 Q 25 30 50 50 T 100 50 T 150 50 T 200 50" stroke="var(--color-accent)" stroke-width="4" fill="none"/>
+        <path d="M0 60 Q 25 40 50 60 T 100 60 T 150 60 T 200 60" stroke="var(--color-accent-light)" stroke-width="4" fill="none"/>
+        <path d="M0 70 Q 25 50 50 70 T 100 70 T 150 70 T 200 70" stroke="var(--color-secondary)" stroke-width="4" fill="none"/>
+      </svg>
+    </div>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -9,12 +9,51 @@
 
 
 body {
-  background-color: var(--color-bg);
-  animation: bg-cycle 20s linear infinite;
+  background-color: #000;
   color: var(--color-text);
   font-family: 'Inter', sans-serif;
   margin: 0;
   padding: 0;
+  position: relative;
+  overflow-x: hidden;
+}
+
+#wave-container {
+  position: fixed;
+  top: 50%;
+  left: 0;
+  width: 100%;
+  height: 25vh;
+  transform: translateY(-50%);
+  pointer-events: none;
+  opacity: 0.3;
+  animation: wave-fade 6s ease-in-out infinite;
+  overflow: hidden;
+}
+
+#wave-container svg {
+  position: absolute;
+  width: 200%;
+  height: 100%;
+  animation: wave-move 10s linear infinite;
+}
+
+@keyframes wave-move {
+  from {
+    transform: translateX(-50%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes wave-fade {
+  0%, 100% {
+    opacity: 0.3;
+  }
+  50% {
+    opacity: 1;
+  }
 }
 a {
   color: var(--color-accent);


### PR DESCRIPTION
## Summary
- set site background to black
- add central `wave-container` with SVG waves
- animate waves moving left-to-right and fading in/out

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869455ffb988320a121499771834b8d