### PR TITLE
Add wider animated stripes and new white line

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,9 +11,10 @@
   <body>
     <div id="wave-container">
       <svg viewBox="0 0 200 100" preserveAspectRatio="none">
-        <path d="M0 50 Q 25 30 50 50 T 100 50 T 150 50 T 200 50" stroke="var(--color-accent)" stroke-width="4" fill="none"/>
-        <path d="M0 60 Q 25 40 50 60 T 100 60 T 150 60 T 200 60" stroke="var(--color-accent-light)" stroke-width="4" fill="none"/>
-        <path d="M0 70 Q 25 50 50 70 T 100 70 T 150 70 T 200 70" stroke="var(--color-secondary)" stroke-width="4" fill="none"/>
+        <path d="M0 50 Q 25 30 50 50 T 100 50 T 150 50 T 200 50" stroke="var(--color-accent)" stroke-width="8" fill="none"/>
+        <path d="M0 60 Q 25 40 50 60 T 100 60 T 150 60 T 200 60" stroke="var(--color-accent-light)" stroke-width="8" fill="none"/>
+        <path d="M0 70 Q 25 50 50 70 T 100 70 T 150 70 T 200 70" stroke="var(--color-secondary)" stroke-width="8" fill="none"/>
+        <path d="M0 80 Q 25 60 50 80 T 100 80 T 150 80 T 200 80" stroke="#ffffff" stroke-width="8" fill="none"/>
       </svg>
     </div>
     <div id="root"></div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -26,6 +26,7 @@ body {
   height: 25vh;
   transform: translateY(-50%);
   pointer-events: none;
+  z-index: -1;
   opacity: 0.3;
   animation: wave-fade 6s ease-in-out infinite;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- widen the animated stripes in the wave container
- add a white stripe beneath the blue one
- ensure the wave container stays behind all content

## Testing
- `npm ci`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68694aeffb148320b9eba3b57a809e5b