### PR TITLE
Enforce min height between navbar and footer

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -7,7 +7,10 @@ const Layout = () => {
   return (
     <div className="d-flex flex-column min-vh-100">
       <Navbar />
-      <div className="container py-4 flex-grow-1">
+      <div
+        className="container py-4 flex-grow-1 d-flex justify-content-center align-items-center"
+        style={{ minHeight: '80vh' }}
+      >
         <Outlet />
       </div>
       <Footer />


### PR DESCRIPTION
## Summary
- enforce an 80vh minimum space between the navbar and footer
- center main content horizontally and vertically

## Testing
- `npm run lint` *(fails: warnings only)*
- `npm test` in backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686a5d996af88320bb5195f02e2ba8bc