### PR TITLE
Apply translucent footer gray to forms and cards

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -89,3 +89,10 @@ a {
     background-color: var(--color-bg);
   }
 }
+
+/* Forms and cards with footer gray background at 50% opacity */
+form,
+.card {
+  background-color: rgba(33, 37, 41, 0.5) !important;
+}
+


### PR DESCRIPTION
## Summary
- make all `<form>` and `.card` elements use the same gray as the footer with 50% opacity

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` in backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686a5fd7eeac8320ba4cdbdd46890b22