### PR TITLE
Revert style change and set light gray background

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,5 @@
 :root {
-  --color-bg: #ffffff;
+  --color-bg: #f2f2f2;
   --color-text: #000000;
   --color-accent: #00c853; /* verde brillante */
   --color-accent-light: #80ff9e; /* celeste-verde claro */
@@ -89,10 +89,3 @@ a {
     background-color: var(--color-bg);
   }
 }
-
-/* Forms and cards with footer gray background at 50% opacity */
-form,
-.card {
-  background-color: rgba(33, 37, 41, 0.5) !important;
-}
-


### PR DESCRIPTION
## Summary
- revert translucent background style on forms and cards
- set the main background color to light gray

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` in backend *(prints "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_686a62d106548320a7066a2231ac1396