### PR TITLE
Fix disappearing carousel

### DIFF
--- a/frontend/src/components/FotoCarousel.jsx
+++ b/frontend/src/components/FotoCarousel.jsx
@@ -31,7 +31,7 @@ const FotoCarousel = ({ fotos }) => {
   };
 
   return (
-    <Slider {...settings} className="photo-carousel carousel slide">
+    <Slider {...settings} className="photo-carousel">
       {fotos.map((f) => (
         <div key={f._id}>
           <img


### PR DESCRIPTION
## Summary
- fix issue where FotoCarousel disappeared by removing conflicting Bootstrap classes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686b411bb5808320854eab91194578fc