### PR TITLE
Fix carousel image URLs via env variable

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# URL base para el backend
+VITE_API_URL=http://localhost:5000

--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: 'http://localhost:5000/api',  // cambiar por tu backend productivo luego
+  baseURL: `${import.meta.env.VITE_API_URL || 'http://localhost:5000'}/api`,
 });
 
 export default api;

--- a/frontend/src/components/FotoCarousel.jsx
+++ b/frontend/src/components/FotoCarousel.jsx
@@ -35,7 +35,7 @@ const FotoCarousel = ({ fotos }) => {
       {fotos.map((f) => (
         <div key={f._id}>
           <img
-            src={`http://localhost:5000/uploads/${f.imagen}`}
+              src={`${import.meta.env.VITE_API_URL || 'http://localhost:5000'}/uploads/${f.imagen}`}
             alt="foto"
             style={{ width: '100%', height: '300px', objectFit: 'contain' }}
           />

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -236,7 +236,7 @@ const Navbar = () => {
                     src={
                       profile.picture.startsWith('http')
                         ? profile.picture
-                        : `http://localhost:5000/uploads/${profile.picture}`
+                          : `${import.meta.env.VITE_API_URL || 'http://localhost:5000'}/uploads/${profile.picture}`
                     }
                     alt="Perfil"
                     className="rounded-circle"

--- a/frontend/src/pages/MisPatinadores.jsx
+++ b/frontend/src/pages/MisPatinadores.jsx
@@ -83,7 +83,7 @@ const MisPatinadores = () => {
                 >
                   {p.foto && (
                     <img
-                      src={`http://localhost:5000/uploads/${p.foto}`}
+                      src={`${import.meta.env.VITE_API_URL || 'http://localhost:5000'}/uploads/${p.foto}`}
                       alt="Foto"
                       className="m-3"
                       style={{ objectFit: 'cover', height: '80vh' }}

--- a/frontend/src/pages/NoticiaDetalle.jsx
+++ b/frontend/src/pages/NoticiaDetalle.jsx
@@ -27,7 +27,7 @@ const NoticiaDetalle = () => {
     <div className="card">
       {noticia.imagen && (
         <img
-          src={`http://localhost:5000/uploads/${noticia.imagen}`}
+          src={`${import.meta.env.VITE_API_URL || 'http://localhost:5000'}/uploads/${noticia.imagen}`}
           className="card-img-top"
           alt="Imagen noticia"
           style={{ objectFit: 'cover', maxHeight: '400px' }}

--- a/frontend/src/pages/Noticias.jsx
+++ b/frontend/src/pages/Noticias.jsx
@@ -33,7 +33,7 @@ const Noticias = () => {
             <div className="card h-100">
               {noticia.imagen && (
                 <img
-                  src={`http://localhost:5000/uploads/${noticia.imagen}`}
+                  src={`${import.meta.env.VITE_API_URL || 'http://localhost:5000'}/uploads/${noticia.imagen}`}
                   className="card-img-top"
                   alt="Imagen noticia"
                   style={{ objectFit: 'cover', height: '200px' }}

--- a/frontend/src/pages/Patinadores.jsx
+++ b/frontend/src/pages/Patinadores.jsx
@@ -51,7 +51,7 @@ const Patinadores = () => {
             <div className="card h-100 text-center">
               {p.fotoRostro && (
                 <img
-                  src={`http://localhost:5000/uploads/${p.fotoRostro}`}
+                  src={`${import.meta.env.VITE_API_URL || 'http://localhost:5000'}/uploads/${p.fotoRostro}`}
                   alt="Rostro"
                   className="rounded-circle mx-auto mt-3"
                   style={{ width: '120px', height: '120px', objectFit: 'cover' }}

--- a/frontend/src/pages/Titulos.jsx
+++ b/frontend/src/pages/Titulos.jsx
@@ -57,7 +57,7 @@ const Titulos = () => {
               <div className="card h-100">
                 {t.imagen && (
                   <img
-                    src={`http://localhost:5000/uploads/${t.imagen}`}
+                    src={`${import.meta.env.VITE_API_URL || 'http://localhost:5000'}/uploads/${t.imagen}`}
                     alt="img"
                     className="card-img-top"
                     style={{ objectFit: 'cover', height: '200px' }}
@@ -102,7 +102,7 @@ const Titulos = () => {
               <div className="card h-100">
                 {t.imagen && (
                   <img
-                    src={`http://localhost:5000/uploads/${t.imagen}`}
+                    src={`${import.meta.env.VITE_API_URL || 'http://localhost:5000'}/uploads/${t.imagen}`}
                     alt="img"
                     className="card-img-top"
                     style={{ objectFit: 'cover', height: '200px' }}

--- a/frontend/src/pages/VerPatinador.jsx
+++ b/frontend/src/pages/VerPatinador.jsx
@@ -29,7 +29,7 @@ const VerPatinador = () => {
 
           {patinador.fotoRostro && (
             <img
-              src={`http://localhost:5000/uploads/${patinador.fotoRostro}`}
+              src={`${import.meta.env.VITE_API_URL || 'http://localhost:5000'}/uploads/${patinador.fotoRostro}`}
               alt="Rostro"
               className="rounded-circle mb-3"
               style={{ width: '200px', height: '200px', objectFit: 'cover' }}
@@ -51,7 +51,7 @@ const VerPatinador = () => {
             <div className="mt-4">
               <h3>Foto Completa:</h3>
               <img
-                src={`http://localhost:5000/uploads/${patinador.foto}`}
+                src={`${import.meta.env.VITE_API_URL || 'http://localhost:5000'}/uploads/${patinador.foto}`}
                 alt="Foto"
                 className="img-fluid"
                 style={{ maxWidth: '400px' }}


### PR DESCRIPTION
## Summary
- add `.env.example` to document backend URL
- read `VITE_API_URL` in `api.js` and all image paths
- build to confirm success

## Testing
- `npm run lint`
- `npm run build`
- `npm test` (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_686b42af0ff08320ab1a8cf2e4b18190