### PR TITLE
Implement tournaments feature

### DIFF
--- a/backend/controllers/torneosController.js
+++ b/backend/controllers/torneosController.js
@@ -1,0 +1,82 @@
+const Torneo = require('../models/Torneo');
+const Competencia = require('../models/Competencia');
+
+exports.crearTorneo = async (req, res) => {
+  try {
+    const { nombre, descripcion, fechaInicio, fechaFin } = req.body;
+    const torneo = new Torneo({
+      nombre,
+      descripcion,
+      fechaInicio,
+      fechaFin,
+      creador: req.user.id,
+      competencias: []
+    });
+    await torneo.save();
+    res.json({ msg: 'Torneo creado correctamente' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: 'Error al crear torneo' });
+  }
+};
+
+exports.listarTorneos = async (req, res) => {
+  try {
+    const torneos = await Torneo.find().populate('competencias');
+    res.json(torneos);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: 'Error al obtener torneos' });
+  }
+};
+
+exports.getRankingTorneo = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const competencias = await Competencia.find({ torneo: id }).populate('resultados.patinador');
+    const acumulado = {};
+    competencias.forEach(comp => {
+      comp.resultados.forEach(res => {
+        const club = res.patinador ? (res.patinador.club || 'General Rodriguez') : (res.club || 'General Rodriguez');
+        const puntos = Number(res.puntos) || 0;
+        acumulado[club] = (acumulado[club] || 0) + puntos;
+      });
+    });
+    const ranking = Object.entries(acumulado)
+      .map(([club, puntos]) => ({ club, puntos }))
+      .sort((a, b) => b.puntos - a.puntos);
+    res.json(ranking);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: 'Error al generar ranking del torneo' });
+  }
+};
+
+exports.getRankingCategoriasTorneo = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const competencias = await Competencia.find({ torneo: id }).populate('resultados.patinador');
+    const acumulado = {};
+    competencias.forEach(comp => {
+      comp.resultados.forEach(res => {
+        const categoria = res.patinador ? res.patinador.categoria : res.categoria;
+        const key = res.patinador ? res.patinador._id.toString() : `${res.nombre}-${res.club}`;
+        if (!acumulado[categoria]) acumulado[categoria] = {};
+        if (!acumulado[categoria][key]) {
+          acumulado[categoria][key] = res.patinador
+            ? { patinador: res.patinador, club: res.patinador.club, puntos: 0 }
+            : { nombre: res.nombre, club: res.club, puntos: 0 };
+        }
+        acumulado[categoria][key].puntos += res.puntos;
+      });
+    });
+    const rankingPorCategoria = {};
+    for (const categoria in acumulado) {
+      rankingPorCategoria[categoria] = Object.values(acumulado[categoria]).sort((a, b) => b.puntos - a.puntos);
+    }
+    res.json(rankingPorCategoria);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: 'Error al generar ranking del torneo' });
+  }
+};

--- a/backend/models/Competencia.js
+++ b/backend/models/Competencia.js
@@ -14,6 +14,7 @@ const competenciaSchema = new mongoose.Schema({
   descripcion: { type: String },
   fecha: { type: Date, required: true },
   clubOrganizador: { type: String },
+  torneo: { type: mongoose.Schema.Types.ObjectId, ref: 'Torneo' },
   creador: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   resultados: [resultadoSchema],
   resultadosClub: [{

--- a/backend/models/Torneo.js
+++ b/backend/models/Torneo.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+
+const torneoSchema = new mongoose.Schema({
+  nombre: { type: String, required: true },
+  descripcion: String,
+  fechaInicio: Date,
+  fechaFin: Date,
+  creador: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  competencias: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Competencia' }]
+});
+
+module.exports = mongoose.model('Torneo', torneoSchema);

--- a/backend/routes/torneosRoutes.js
+++ b/backend/routes/torneosRoutes.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const router = express.Router();
+const torneoController = require('../controllers/torneosController');
+const auth = require('../middleware/authMiddleware');
+const checkRole = require('../middleware/roleMiddleware');
+
+router.post('/', auth, checkRole(['Delegado']), torneoController.crearTorneo);
+router.get('/', auth, torneoController.listarTorneos);
+router.get('/:id/ranking', auth, torneoController.getRankingTorneo);
+router.get('/:id/ranking-categorias', auth, torneoController.getRankingCategoriasTorneo);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -17,6 +17,7 @@ app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
 app.use('/api/patinadores', require('./routes/patinadoresRoutes'));
 app.use('/api/gestion-patinadores', require('./routes/gestionPatinadoresRoutes'));
 app.use('/api/competencias', require('./routes/competenciasRoutes'));
+app.use('/api/torneos', require('./routes/torneosRoutes'));
 app.use('/api/ranking', require('./routes/rankingRoutes'));
 app.use('/api/titulos', require('./routes/titulosRoutes'));
 app.use('/api/notificaciones', require('./routes/notificationRoutes'));

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,6 +20,8 @@ import Competencias from './pages/Competencias';
 import VerCompetencia from './pages/VerCompetencia';
 import ResultadosCompetencia from './pages/ResultadosCompetencia';
 import ResultadosDetalle from './pages/ResultadosDetalle';
+import Torneos from './pages/Torneos';
+import CrearTorneo from './pages/CrearTorneo';
 import RankingGeneral from './pages/RankingGeneral';
 import RankingPorCategorias from './pages/RankingPorCategorias';
 import ResultadosClubCompetencia from './pages/ResultadosClubCompetencia';
@@ -58,6 +60,8 @@ const App = () => {
            <Route path="patinadores" element={<Patinadores />} />
            <Route path="editar-patinador/:id" element={<EditarPatinador />} />
            <Route path="patinador/:id" element={<VerPatinador />} />
+           <Route path="torneos" element={<Torneos />} />
+           <Route path="crear-torneo" element={<CrearTorneo />} />
            <Route path="crear-competencia" element={<CrearCompetencia />} />
           <Route path="competencias" element={<Competencias />} />
           <Route path="competencias/editar/:id" element={<EditarCompetencia />} />

--- a/frontend/src/api/torneos.js
+++ b/frontend/src/api/torneos.js
@@ -1,0 +1,29 @@
+import api from './api';
+
+export const crearTorneo = async (data, token) => {
+  const res = await api.post('/torneos', data, {
+    headers: { Authorization: token }
+  });
+  return res.data;
+};
+
+export const listarTorneos = async (token) => {
+  const res = await api.get('/torneos', {
+    headers: { Authorization: token }
+  });
+  return res.data;
+};
+
+export const getRankingTorneo = async (id, token) => {
+  const res = await api.get(`/torneos/${id}/ranking`, {
+    headers: { Authorization: token }
+  });
+  return res.data;
+};
+
+export const getRankingCategoriasTorneo = async (id, token) => {
+  const res = await api.get(`/torneos/${id}/ranking-categorias`, {
+    headers: { Authorization: token }
+  });
+  return res.data;
+};

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -163,9 +163,11 @@ const Navbar = () => {
                   data-bs-toggle="dropdown"
                   aria-expanded="false"
                 >
-                  Competencias
+                  Torneos
                 </a>
                 <ul className="dropdown-menu" aria-labelledby="competenciasDropdown">
+                  <li><Link className="dropdown-item" to="/torneos">Torneos</Link></li>
+                  <li><Link className="dropdown-item" to="/crear-torneo">Crear Torneo</Link></li>
                   <li><Link className="dropdown-item" to="/competencias">Competencias</Link></li>
                   <li><Link className="dropdown-item" to="/crear-competencia">Crear Competencia</Link></li>
                 </ul>

--- a/frontend/src/pages/CrearCompetencia.jsx
+++ b/frontend/src/pages/CrearCompetencia.jsx
@@ -1,23 +1,38 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import useAuth from '../store/useAuth';
 import { crearCompetencia } from '../api/competencias';
+import { listarTorneos } from '../api/torneos';
 import { useNavigate } from 'react-router-dom';
 
 const CrearCompetencia = () => {
   const { token } = useAuth();
   const navigate = useNavigate();
+  const [torneos, setTorneos] = useState([]);
 
   const [form, setForm] = useState({
     nombre: '',
     descripcion: '',
     fecha: '',
-    clubOrganizador: ''
+    clubOrganizador: '',
+    torneo: ''
   });
 
   const handleChange = e => {
     const { name, value } = e.target;
     setForm(prev => ({ ...prev, [name]: value }));
   };
+
+  useEffect(() => {
+    const fetchTorneos = async () => {
+      try {
+        const data = await listarTorneos(token);
+        setTorneos(data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchTorneos();
+  }, [token]);
 
   const handleSubmit = async e => {
     e.preventDefault();
@@ -44,8 +59,14 @@ const CrearCompetencia = () => {
           onChange={handleChange}
           className="form-control my-2"
         />
+        <select name="torneo" onChange={handleChange} className="form-select my-2">
+          <option value="">Sin torneo</option>
+          {torneos.map(t => (
+            <option key={t._id} value={t._id}>{t.nombre}</option>
+          ))}
+        </select>
         <input type="date" name="fecha" onChange={handleChange} required />
-        <button type="submit">Crear</button>
+        <button type="submit" className="btn btn-primary mt-2">Crear</button>
       </form>
     </div>
   );

--- a/frontend/src/pages/CrearTorneo.jsx
+++ b/frontend/src/pages/CrearTorneo.jsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import useAuth from '../store/useAuth';
+import { crearTorneo } from '../api/torneos';
+import { useNavigate } from 'react-router-dom';
+
+const CrearTorneo = () => {
+  const { token } = useAuth();
+  const navigate = useNavigate();
+  const [form, setForm] = useState({ nombre: '', descripcion: '', fechaInicio: '', fechaFin: '' });
+
+  const handleChange = e => {
+    const { name, value } = e.target;
+    setForm(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    try {
+      await crearTorneo(form, token);
+      alert('Torneo creado');
+      navigate('/torneos');
+    } catch (err) {
+      console.error(err);
+      alert('Error al crear torneo');
+    }
+  };
+
+  return (
+    <div>
+      <h2>Crear Torneo</h2>
+      <form onSubmit={handleSubmit}>
+        <input name="nombre" placeholder="Nombre" onChange={handleChange} required />
+        <textarea name="descripcion" placeholder="Descripción" onChange={handleChange} className="form-control my-2" />
+        <input type="date" name="fechaInicio" onChange={handleChange} />
+        <input type="date" name="fechaFin" onChange={handleChange} className="ms-2" />
+        <button type="submit" className="btn btn-primary ms-2">Crear</button>
+      </form>
+    </div>
+  );
+};
+
+export default CrearTorneo;

--- a/frontend/src/pages/Torneos.jsx
+++ b/frontend/src/pages/Torneos.jsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react';
+import useAuth from '../store/useAuth';
+import { listarTorneos } from '../api/torneos';
+import { useNavigate } from 'react-router-dom';
+import formatDate from '../utils/formatDate';
+
+const Torneos = () => {
+  const { token } = useAuth();
+  const navigate = useNavigate();
+  const [torneos, setTorneos] = useState([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const data = await listarTorneos(token);
+        setTorneos(data);
+      } catch (err) {
+        console.error(err);
+        alert('Error al obtener torneos');
+      }
+    };
+    fetchData();
+  }, [token]);
+
+  return (
+    <div>
+      <h2>Torneos</h2>
+      <ul className="list-group">
+        {torneos.map(t => (
+          <li key={t._id} className="list-group-item d-flex justify-content-between align-items-center">
+            <span><strong>{t.nombre}</strong>{t.fechaInicio ? ` - ${formatDate(t.fechaInicio)}` : ''}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default Torneos;


### PR DESCRIPTION
## Summary
- add Torneo model and create controller/routes
- link Competencia with Torneo
- allow creating competitions for a tournament
- add pages to create/list tournaments in the frontend
- update navigation and routing to include tournaments

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686dd750595883209c8294bb135d7b81