### PR TITLE
Add external runner number field

### DIFF
--- a/backend/controllers/competenciasController.js
+++ b/backend/controllers/competenciasController.js
@@ -108,6 +108,9 @@ exports.agregarResultados = async (req, res) => {
           posicion: Number(r.posicion),
           puntos: Number(r.puntos)
         };
+        if (res.numeroCorredor !== undefined && res.numeroCorredor !== null) {
+          res.numeroCorredor = Number(res.numeroCorredor);
+        }
         if (!res.patinador) {
           delete res.patinador;
         }

--- a/backend/models/Competencia.js
+++ b/backend/models/Competencia.js
@@ -2,6 +2,7 @@ const mongoose = require('mongoose');
 
 const resultadoSchema = new mongoose.Schema({
   patinador: { type: mongoose.Schema.Types.ObjectId, ref: 'Patinador' },
+  numeroCorredor: { type: Number },
   nombre: { type: String },
   club: { type: String },
   categoria: { type: String },

--- a/frontend/src/pages/ResultadosCompetencia.jsx
+++ b/frontend/src/pages/ResultadosCompetencia.jsx
@@ -37,7 +37,7 @@ const ResultadosCompetencia = () => {
   const agregarPatinador = () => {
     setResultados([
       ...resultados,
-      { patinador: '', nombre: '', club: '', categoria: categoriaActual, posicion: '', puntos: '' }
+      { patinador: '', numeroCorredor: '', nombre: '', club: '', categoria: categoriaActual, posicion: '', puntos: '' }
     ]);
   };
 
@@ -117,6 +117,16 @@ const ResultadosCompetencia = () => {
 
                     {!res.patinador && (
                       <>
+                        <div className="col-12 col-md">
+                          <input
+                            className="form-control"
+                            type="number"
+                            placeholder="Número"
+                            value={res.numeroCorredor}
+                            onChange={e => handleChange(index, 'numeroCorredor', e.target.value)}
+                            required
+                          />
+                        </div>
                         <div className="col-12 col-md">
                           <input
                             className="form-control"


### PR DESCRIPTION
## Summary
- include `numeroCorredor` in `resultadoSchema`
- parse and store runner number when saving results
- prompt for runner number on results page for external athletes

## Testing
- `npm test` (backend) – fails: Error: no test specified
- `npm test` (frontend) – fails: Missing script `test`


------
https://chatgpt.com/codex/tasks/task_e_6870817cbbfc8320b65beac6fe80919c