### PR TITLE
Fix category filter for skaters

### DIFF
--- a/frontend/src/pages/ResultadosCompetencia.jsx
+++ b/frontend/src/pages/ResultadosCompetencia.jsx
@@ -48,6 +48,14 @@ const ResultadosCompetencia = () => {
   const handleChange = (index, field, value) => {
     const nuevos = [...resultados];
     nuevos[index][field] = value;
+
+    if (field === 'patinador') {
+      const pat = patinadores.find(p => p._id === value);
+      if (pat) {
+        nuevos[index].categoria = pat.categoria;
+      }
+    }
+
     setResultados(nuevos);
   };
 
@@ -109,7 +117,11 @@ const ResultadosCompetencia = () => {
                             p.numeroCorredor
                               ?.toString()
                               .includes(filtroNumero)
-                          && (categoriaActual ? p.categoria === categoriaActual : true)
+                          && (res.categoria
+                              ? p.categoria === res.categoria
+                              : categoriaActual
+                              ? p.categoria === categoriaActual
+                              : true)
                           )
                           .map(p => (
                             <option key={p._id} value={p._id}>


### PR DESCRIPTION
## Summary
- ensure selected skater sets the result category
- filter skaters by the row's category when searching by number

## Testing
- `npm run lint` *(fails: React hook dependency warnings only)*
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_6870cad9aa8c83209197ee01c7635401