### PR TITLE
Fix category filter in results form

### DIFF
--- a/frontend/src/pages/ResultadosCompetencia.jsx
+++ b/frontend/src/pages/ResultadosCompetencia.jsx
@@ -117,11 +117,12 @@ const ResultadosCompetencia = () => {
                             p.numeroCorredor
                               ?.toString()
                               .includes(filtroNumero)
-                          && (res.categoria
-                              ? p.categoria === res.categoria
-                              : categoriaActual
-                              ? p.categoria === categoriaActual
-                              : true)
+                          && (
+                            !categoriaActual
+                              ||
+                                p.categoria?.trim().toUpperCase() ===
+                                  categoriaActual.trim().toUpperCase()
+                          )
                           )
                           .map(p => (
                             <option key={p._id} value={p._id}>


### PR DESCRIPTION
## Summary
- filter skater dropdown using currently selected category only

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687187a565e48320a46f9a041d476926