### PR TITLE
Add category support for external skaters

### DIFF
--- a/backend/controllers/competenciasController.js
+++ b/backend/controllers/competenciasController.js
@@ -142,8 +142,8 @@ exports.agregarResultados = async (req, res) => {
       if (!res.patinador && res.numeroCorredor && res.nombre) {
         extOps.push(
           PatinadorExterno.findOneAndUpdate(
-            { numeroCorredor: res.numeroCorredor },
-            { nombre: res.nombre, club: res.club },
+            { numeroCorredor: res.numeroCorredor, categoria: res.categoria },
+            { nombre: res.nombre, club: res.club, categoria: res.categoria },
             { upsert: true, new: true }
           )
         );

--- a/backend/controllers/patinadoresExternosController.js
+++ b/backend/controllers/patinadoresExternosController.js
@@ -2,10 +2,13 @@ const PatinadorExterno = require('../models/PatinadorExterno');
 
 exports.listar = async (req, res) => {
   try {
-    const { numero } = req.query;
+    const { numero, categoria } = req.query;
     const query = {};
     if (numero) {
       query.numeroCorredor = Number(numero);
+    }
+    if (categoria) {
+      query.categoria = categoria;
     }
     const patinadores = await PatinadorExterno.find(query).sort({ numeroCorredor: 1 });
     res.json(patinadores);

--- a/backend/models/PatinadorExterno.js
+++ b/backend/models/PatinadorExterno.js
@@ -1,9 +1,12 @@
 const mongoose = require('mongoose');
 
 const patinadorExternoSchema = new mongoose.Schema({
-  numeroCorredor: { type: Number, required: true, unique: true },
+  numeroCorredor: { type: Number, required: true },
   nombre: { type: String, required: true },
-  club: { type: String }
+  club: { type: String },
+  categoria: { type: String }
 });
+
+patinadorExternoSchema.index({ numeroCorredor: 1, categoria: 1 }, { unique: true });
 
 module.exports = mongoose.model('PatinadorExterno', patinadorExternoSchema);

--- a/frontend/src/api/patinadoresExternos.js
+++ b/frontend/src/api/patinadoresExternos.js
@@ -1,7 +1,8 @@
 import api from './api';
 
-export const listarPatinadoresExternos = async (token) => {
+export const listarPatinadoresExternos = async (token, categoria) => {
   const res = await api.get('/patinadores-externos', {
+    params: categoria ? { categoria } : {},
     headers: { Authorization: token }
   });
   return res.data;

--- a/frontend/src/pages/ResultadosCompetencia.jsx
+++ b/frontend/src/pages/ResultadosCompetencia.jsx
@@ -22,10 +22,8 @@ const ResultadosCompetencia = () => {
       const lista = await obtenerListaBuenaFe(id, token);
       const comps = await listarCompetencias(token);
       const comp = comps.find(c => c._id === id);
-      const externos = await listarPatinadoresExternos(token);
 
       setPatinadores(lista);
-      setPatinadoresExternos(externos);
       setCompetencia(comp);
       setResultados([]);
       const cats = Array.from(new Set(lista.map(p => p.categoria))).sort();
@@ -37,6 +35,16 @@ const ResultadosCompetencia = () => {
 
     fetchData();
   }, []);
+
+  useEffect(() => {
+    const fetchExternos = async () => {
+      if (!categoriaActual) return;
+      const externos = await listarPatinadoresExternos(token, categoriaActual);
+      setPatinadoresExternos(externos);
+    };
+
+    fetchExternos();
+  }, [categoriaActual, token]);
 
   const agregarPatinador = () => {
     setResultados([
@@ -145,7 +153,11 @@ const ResultadosCompetencia = () => {
                             onChange={e => {
                               const val = e.target.value;
                               handleChange(index, 'numeroCorredor', val);
-                              const ext = patinadoresExternos.find(p => p.numeroCorredor?.toString() === val);
+                              const ext = patinadoresExternos.find(
+                                p =>
+                                  p.numeroCorredor?.toString() === val &&
+                                  p.categoria === categoriaActual
+                              );
                               if (ext) {
                                 handleChange(index, 'nombre', ext.nombre);
                                 handleChange(index, 'club', ext.club || '');


### PR DESCRIPTION
## Summary
- add category field to external skater model and make number/category unique
- allow querying external skaters by category
- store category when saving external results
- fetch external skaters per category on results page
- update external skater lookup by number and category

## Testing
- `npm test` in backend (fails: Error: no test specified)
- `npm run lint` in frontend

------
https://chatgpt.com/codex/tasks/task_e_6871a1b7a580832090ae57eb39c497e0