### PR TITLE
Add external skater registry and auto-fill

### DIFF
--- a/backend/controllers/patinadoresExternosController.js
+++ b/backend/controllers/patinadoresExternosController.js
@@ -17,3 +17,21 @@ exports.listar = async (req, res) => {
     res.status(500).json({ msg: 'Error al obtener patinadores externos' });
   }
 };
+
+exports.crear = async (req, res) => {
+  try {
+    const { numeroCorredor, nombre, club, categoria } = req.body;
+    if (!numeroCorredor || !nombre) {
+      return res.status(400).json({ msg: 'Número y nombre requeridos' });
+    }
+    await PatinadorExterno.findOneAndUpdate(
+      { numeroCorredor, categoria },
+      { numeroCorredor, nombre, club, categoria },
+      { upsert: true, new: true }
+    );
+    res.json({ msg: 'Patinador externo guardado' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: 'Error al guardar patinador externo' });
+  }
+};

--- a/backend/routes/patinadoresExternosRoutes.js
+++ b/backend/routes/patinadoresExternosRoutes.js
@@ -4,5 +4,6 @@ const controller = require('../controllers/patinadoresExternosController');
 const auth = require('../middleware/authMiddleware');
 
 router.get('/', auth, controller.listar);
+router.post('/', auth, controller.crear);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add POST endpoint for `/api/patinadores-externos`
- implement controller method to create or update external skaters
- auto-fill external skater data when adding competition results

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68721cebe3948320a9d2de68adf59280