### PR TITLE
Fix Google OAuth provider setup

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,3 @@
 # URL base para el backend
 VITE_API_URL=http://localhost:5000
+VITE_GOOGLE_CLIENT_ID=483587451822-fjrc9gpgaegbbh1pvlbq8qpbc9sauve1.apps.googleusercontent.com

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { GoogleOAuthProvider } from '@react-oauth/google';
 import App from './App';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <GoogleOAuthProvider clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </GoogleOAuthProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- wrap the app in `GoogleOAuthProvider`
- expose `VITE_GOOGLE_CLIENT_ID` in `.env.example`

## Testing
- `npm run lint` in `frontend`
- `npm test` in `backend` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_6875a181ad748320b5f04f0985d07de1