### PR TITLE
Fix path-to-regexp error on startup

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -26,7 +26,6 @@ const corsOptions = {
 };
 
 app.use(cors(corsOptions));
-app.options('*', cors(corsOptions));
 
 // Rutas
 app.use('/api/auth', require('./routes/authRoutes'));


### PR DESCRIPTION
## Summary
- remove wildcard `app.options('*', cors())` which crashes express 5

## Testing
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68761200494483208049f8123208f213