### PR TITLE
Fix login config issues

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -10,3 +10,7 @@ apropiada.
 Para empezar puedes copiar el archivo `.env.example` como `.env` y rellenar sus
 valores. Si obtienes errores de DNS al usar una URI `mongodb+srv://`, cambia a
 la forma estándar `mongodb://usuario:contraseña@host:puerto/nombre_bd`.
+
+El valor de `CLIENT_URL` debe coincidir con la URL de tu frontend (por ejemplo
+`https://apppatin-frontend.onrender.com`) para que el middleware CORS permita
+las solicitudes.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -16,3 +16,5 @@ If you are developing a production application, we recommend using TypeScript wi
 Create a `.env` file in this folder based on `.env.example`. Set `VITE_GOOGLE_CLIENT_ID` to your Google OAuth Client ID.
 Make sure that the client ID allows your deployment domain (e.g. `https://apppatin-frontend.onrender.com`) under "Authorized JavaScript origins" in the Google Cloud console.
 
+If `VITE_GOOGLE_CLIENT_ID` is not set when the app is built, the Google login button will be disabled and a warning will appear in the browser console.
+

--- a/frontend/src/components/Auth/Login.jsx
+++ b/frontend/src/components/Auth/Login.jsx
@@ -10,6 +10,7 @@ import useAuth from '../../store/useAuth';
 const Login = () => {
   const navigate = useNavigate();
   const { login } = useAuth();
+  const googleClientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
   const [form, setForm] = useState({ email: '', password: '' });
 
   const handleChange = e => setForm({ ...form, [e.target.name]: e.target.value });
@@ -38,23 +39,29 @@ const Login = () => {
             <input className="form-control" name="password" type="password" placeholder="Password" onChange={handleChange} required />
           </div>
           <button className="btn btn-primary w-100 mb-3" type="submit">Iniciar sesión</button>
-          <GoogleLogin
-            onSuccess={async (credentialResponse) => {
-              const { credential } = credentialResponse;
-              const decoded = jwtDecode(credential);
-              const userData = {
-                nombre: decoded.given_name,
-                apellido: decoded.family_name,
-                email: decoded.email,
-                googleId: decoded.sub,
-                picture: decoded.picture,
-              };
-              const res = await api.post('/auth/google-login', userData);
-              login(res.data.token);
-              navigate('/dashboard');
-            }}
-            onError={() => alert('Google Login fallido')}
-          />
+          {googleClientId ? (
+            <GoogleLogin
+              onSuccess={async (credentialResponse) => {
+                const { credential } = credentialResponse;
+                const decoded = jwtDecode(credential);
+                const userData = {
+                  nombre: decoded.given_name,
+                  apellido: decoded.family_name,
+                  email: decoded.email,
+                  googleId: decoded.sub,
+                  picture: decoded.picture,
+                };
+                const res = await api.post('/auth/google-login', userData);
+                login(res.data.token);
+                navigate('/dashboard');
+              }}
+              onError={() => alert('Google Login fallido')}
+            />
+          ) : (
+            <div className="alert alert-warning text-center" role="alert">
+              Configura VITE_GOOGLE_CLIENT_ID para habilitar Google Login
+            </div>
+          )}
           <div className="text-center mt-3">
             <button type="button" className="btn btn-link" onClick={() => navigate('/register')}>Registrarme</button>
           </div>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -5,9 +5,16 @@ import { GoogleOAuthProvider } from '@react-oauth/google';
 import App from './App';
 import './index.css';
 
+const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+if (!clientId) {
+  console.warn(
+    'VITE_GOOGLE_CLIENT_ID is not set. Google login will be disabled.'
+  );
+}
+
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <GoogleOAuthProvider clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID}>
+    <GoogleOAuthProvider clientId={clientId || ''}>
       <BrowserRouter>
         <App />
       </BrowserRouter>


### PR DESCRIPTION
## Summary
- warn if `VITE_GOOGLE_CLIENT_ID` isn't defined and disable Google login
- show a warning in the login page when Google login isn't available
- document Google auth environment requirement in the frontend README
- document `CLIENT_URL` for CORS in backend README

## Testing
- `npm test` (fails: no test specified)
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6877cfdf78048320abf735dcd50c1cc8