### PR TITLE
Fix express preflight route

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -27,7 +27,6 @@ const corsOptions = {
 
 app.use(cors(corsOptions));
 // Ensure preflight requests always receive CORS headers
-app.options('*', cors(corsOptions));
 
 // Rutas
 app.use('/api/auth', require('./routes/authRoutes'));


### PR DESCRIPTION
## Summary
- remove wildcard options path to prevent path-to-regexp error

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_687844081a8883208e9c2451f196ea71