### PR TITLE
Fix Express preflight route

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -26,8 +26,9 @@ const corsOptions = {
 };
 
 app.use(cors(corsOptions));
-// Ensure preflight requests always receive CORS headers
-app.options('*', cors(corsOptions));
+// Ensure CORS headers for preflight requests
+// Express 5 requires a named wildcard parameter
+app.options('/*all', cors(corsOptions));
 
 // Rutas
 app.use('/api/auth', require('./routes/authRoutes'));


### PR DESCRIPTION
## Summary
- handle preflight requests using an Express 5 compatible wildcard

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687a3f1e90648320a3454c3722a71c3d