### PR TITLE
Update frontend backend URL

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,4 +1,4 @@
 # URL base para el backend
-VITE_API_URL=https://apppatin-1.onrender.com
+VITE_API_URL=https://backend-app-s246.onrender.com
 # ID de cliente OAuth de Google para el login
 VITE_GOOGLE_CLIENT_ID=483587451822-fjrc9gpgaegbbh1pvlbq8qpbc9sauve1.apps.googleusercontent.com

--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: `${import.meta.env.VITE_API_URL || 'https://apppatin-1.onrender.com'}/api`,
+  baseURL: `${import.meta.env.VITE_API_URL || 'https://backend-app-s246.onrender.com'}/api`,
 });
 
 export default api;

--- a/frontend/src/components/FotoCarousel.jsx
+++ b/frontend/src/components/FotoCarousel.jsx
@@ -52,7 +52,7 @@ const FotoCarousel = ({ fotos }) => {
       {fotos.map((f) => (
         <div key={f._id}>
           <img
-              src={`${import.meta.env.VITE_API_URL || 'https://apppatin-1.onrender.com'}/uploads/${f.imagen}`}
+              src={`${import.meta.env.VITE_API_URL || 'https://backend-app-s246.onrender.com'}/uploads/${f.imagen}`}
             alt="foto"
             style={{ width: '100%', height: '300px', objectFit: 'contain' }}
           />

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -238,7 +238,7 @@ const Navbar = () => {
                     src={
                       profile.picture.startsWith('http')
                         ? profile.picture
-                          : `${import.meta.env.VITE_API_URL || 'https://apppatin-1.onrender.com'}/uploads/${profile.picture}`
+                          : `${import.meta.env.VITE_API_URL || 'https://backend-app-s246.onrender.com'}/uploads/${profile.picture}`
                     }
                     alt="Perfil"
                     className="rounded-circle"

--- a/frontend/src/pages/MisPatinadores.jsx
+++ b/frontend/src/pages/MisPatinadores.jsx
@@ -83,7 +83,7 @@ const MisPatinadores = () => {
                 >
                   {p.foto && (
                     <img
-                      src={`${import.meta.env.VITE_API_URL || 'https://apppatin-1.onrender.com'}/uploads/${p.foto}`}
+                      src={`${import.meta.env.VITE_API_URL || 'https://backend-app-s246.onrender.com'}/uploads/${p.foto}`}
                       alt="Foto"
                       className="m-3"
                       style={{ objectFit: 'cover', height: '80vh' }}

--- a/frontend/src/pages/NoticiaDetalle.jsx
+++ b/frontend/src/pages/NoticiaDetalle.jsx
@@ -27,7 +27,7 @@ const NoticiaDetalle = () => {
     <div className="card">
       {noticia.imagen && (
         <img
-          src={`${import.meta.env.VITE_API_URL || 'https://apppatin-1.onrender.com'}/uploads/${noticia.imagen}`}
+          src={`${import.meta.env.VITE_API_URL || 'https://backend-app-s246.onrender.com'}/uploads/${noticia.imagen}`}
           className="card-img-top"
           alt="Imagen noticia"
           style={{ objectFit: 'cover', maxHeight: '400px' }}

--- a/frontend/src/pages/Noticias.jsx
+++ b/frontend/src/pages/Noticias.jsx
@@ -33,7 +33,7 @@ const Noticias = () => {
             <div className="card h-100">
               {noticia.imagen && (
                 <img
-                  src={`${import.meta.env.VITE_API_URL || 'https://apppatin-1.onrender.com'}/uploads/${noticia.imagen}`}
+                  src={`${import.meta.env.VITE_API_URL || 'https://backend-app-s246.onrender.com'}/uploads/${noticia.imagen}`}
                   className="card-img-top"
                   alt="Imagen noticia"
                   style={{ objectFit: 'cover', height: '200px' }}

--- a/frontend/src/pages/Patinadores.jsx
+++ b/frontend/src/pages/Patinadores.jsx
@@ -51,7 +51,7 @@ const Patinadores = () => {
             <div className="card h-100 text-center">
               {p.fotoRostro && (
                 <img
-                  src={`${import.meta.env.VITE_API_URL || 'https://apppatin-1.onrender.com'}/uploads/${p.fotoRostro}`}
+                  src={`${import.meta.env.VITE_API_URL || 'https://backend-app-s246.onrender.com'}/uploads/${p.fotoRostro}`}
                   alt="Rostro"
                   className="rounded-circle mx-auto mt-3"
                   style={{ width: '120px', height: '120px', objectFit: 'cover' }}

--- a/frontend/src/pages/Titulos.jsx
+++ b/frontend/src/pages/Titulos.jsx
@@ -57,7 +57,7 @@ const Titulos = () => {
               <div className="card h-100">
                 {t.imagen && (
                   <img
-                    src={`${import.meta.env.VITE_API_URL || 'https://apppatin-1.onrender.com'}/uploads/${t.imagen}`}
+                    src={`${import.meta.env.VITE_API_URL || 'https://backend-app-s246.onrender.com'}/uploads/${t.imagen}`}
                     alt="img"
                     className="card-img-top"
                     style={{ objectFit: 'cover', height: '200px' }}
@@ -102,7 +102,7 @@ const Titulos = () => {
               <div className="card h-100">
                 {t.imagen && (
                   <img
-                    src={`${import.meta.env.VITE_API_URL || 'https://apppatin-1.onrender.com'}/uploads/${t.imagen}`}
+                    src={`${import.meta.env.VITE_API_URL || 'https://backend-app-s246.onrender.com'}/uploads/${t.imagen}`}
                     alt="img"
                     className="card-img-top"
                     style={{ objectFit: 'cover', height: '200px' }}

--- a/frontend/src/pages/VerPatinador.jsx
+++ b/frontend/src/pages/VerPatinador.jsx
@@ -29,7 +29,7 @@ const VerPatinador = () => {
 
           {patinador.fotoRostro && (
             <img
-              src={`${import.meta.env.VITE_API_URL || 'https://apppatin-1.onrender.com'}/uploads/${patinador.fotoRostro}`}
+              src={`${import.meta.env.VITE_API_URL || 'https://backend-app-s246.onrender.com'}/uploads/${patinador.fotoRostro}`}
               alt="Rostro"
               className="rounded-circle mb-3"
               style={{ width: '200px', height: '200px', objectFit: 'cover' }}
@@ -51,7 +51,7 @@ const VerPatinador = () => {
             <div className="mt-4">
               <h3>Foto Completa:</h3>
               <img
-                src={`${import.meta.env.VITE_API_URL || 'https://apppatin-1.onrender.com'}/uploads/${patinador.foto}`}
+                src={`${import.meta.env.VITE_API_URL || 'https://backend-app-s246.onrender.com'}/uploads/${patinador.foto}`}
                 alt="Foto"
                 className="img-fluid"
                 style={{ maxWidth: '400px' }}


### PR DESCRIPTION
## Summary
- switch default API URL to `backend-app-s246.onrender.com`
- update example `.env` with new backend URL
- fix image URL fallbacks across the React app

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a42e51d748320a4367720ba4f6941