### PR TITLE
Fix CORS for Vercel frontend

### DIFF
--- a/backend/config/corsOptions.js
+++ b/backend/config/corsOptions.js
@@ -6,9 +6,11 @@ const allowedOrigins = process.env.ALLOWED_ORIGINS
       'http://localhost:5173',
     ];
 
+const isVercelDomain = (origin) => /\.vercel\.app$/.test(origin || '');
+
 module.exports = {
   origin: (origin, callback) => {
-    if (!origin || allowedOrigins.includes(origin)) {
+    if (!origin || allowedOrigins.includes(origin) || isVercelDomain(origin)) {
       callback(null, true);
     } else {
       callback(new Error('Not allowed by CORS'));

--- a/backend/server.js
+++ b/backend/server.js
@@ -11,9 +11,8 @@ const app = express();
 app.use(express.json());
 
 app.use(cors(corsOptions));
-// Ensure CORS headers for preflight requests
-// Express 5 requires a named wildcard parameter
-app.options('/*all', cors(corsOptions));
+// Ensure CORS headers for preflight requests on any route
+app.options('*', cors(corsOptions));
 
 // Rutas
 app.use('/api/auth', require('./routes/authRoutes'));


### PR DESCRIPTION
## Summary
- allow all `vercel.app` origins in CORS config
- fix `app.options('*')` to respond to preflight requests

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687a65ec88fc8320a6163a5f46a836f2