### PR TITLE
Fix Google OAuth origin guidance

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -26,3 +26,4 @@ ALLOWED_ORIGINS=http://localhost:5173,https://apppatin-frontend.onrender.com
 
 Además debes definir `GOOGLE_CLIENT_ID` con el ID de cliente OAuth de Google si
 quieres habilitar el inicio de sesión con Google.
+Para evitar el error `origin_mismatch` de Google, asegúrate de que la URL configurada en `CLIENT_URL` y cualquier dominio donde despliegues el frontend estén registrados como **Authorized JavaScript origins** del cliente OAuth en la Google Cloud Console.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -2,3 +2,4 @@
 VITE_API_URL=https://backend-app-s246.onrender.com
 # ID de cliente OAuth de Google para el login
 VITE_GOOGLE_CLIENT_ID=483587451822-fjrc9gpgaegbbh1pvlbq8qpbc9sauve1.apps.googleusercontent.com
+# Agrega tu dominio a "Authorized JavaScript origins" en Google Cloud Console

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -18,3 +18,4 @@ Make sure that the client ID allows your deployment domain (e.g. `https://apppat
 
 If `VITE_GOOGLE_CLIENT_ID` is not set when the app is built, the Google login button will be disabled and a warning will appear in the browser console.
 
+If you see a 400 `origin_mismatch` error when signing in with Google, confirm that your deployment URL is listed under "Authorized JavaScript origins" for the OAuth client in Google Cloud Console.


### PR DESCRIPTION
## Summary
- clarify need to register JavaScript origin in Google Cloud
- mention origin_mismatch troubleshooting

## Testing
- `npm run lint` *(fails: warnings only)*
- `npm test` in backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687a78cde7ac8320b467d13cdce54180