### PR TITLE
Fix Express path-to-regexp crash

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -11,8 +11,6 @@ const app = express();
 app.use(express.json());
 
 app.use(cors(corsOptions));
-// Ensure CORS headers for preflight requests on any route
-app.options('*', cors(corsOptions));
 
 // Rutas
 app.use('/api/auth', require('./routes/authRoutes'));


### PR DESCRIPTION
## Summary
- fix server startup crash by removing `app.options('*', cors(corsOptions))`

## Testing
- `npm test` (fails: no test specified)
- `npm test` in frontend (fails: missing script)


------
https://chatgpt.com/codex/tasks/task_e_687a7bdb5cac8320af690aa20173e496