### PR TITLE
Fix duplicate allowedOrigins constant

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -2,10 +2,6 @@ require('dotenv').config();
 const express = require('express');
 const connectDB = require('./config/db');
 const cors = require('cors');
-const allowedOrigins = [
-  'https://app-patin-ekcu.vercel.app',
-  'https://app-patin-ekcu-gastonmanzurs-projects.vercel.app', // si estás usando previews también
-];
 const path = require('path');
 
 const app = express();


### PR DESCRIPTION
## Summary
- remove the duplicate declaration of `allowedOrigins` in `server.js`

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687b93379de083209f3d5353dd311872