### PR TITLE
Fix CORS for Vercel preview domains

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -18,14 +18,19 @@ app.use(express.urlencoded({ extended: true }));
 const allowedOrigins = process.env.ALLOWED_ORIGINS
   ? process.env.ALLOWED_ORIGINS.split(',').map(o => o.trim())
   : [
-    'https://app-patin-ekcu-p0bz5vl8t-gastonmanzurs-projects.vercel.app',
-      'https://app-patin-ekcu.vercel.app',
-      'https://app-patin-ekcu-gastonmanzurs-projects.vercel.app', // preview de Vercel
-    ];
+    'https://app-patin-ekcu.vercel.app',
+  ];
+
+// Permitir cualquier dominio de preview generado por Vercel para este proyecto
+const vercelPreviewRegex = /^https:\/\/app-patin-ekcu.*\.vercel\.app$/;
 
 app.use(cors({
   origin: function (origin, callback) {
-    if (!origin || allowedOrigins.includes(origin)) {
+    if (
+      !origin ||
+      allowedOrigins.includes(origin) ||
+      vercelPreviewRegex.test(origin)
+    ) {
       callback(null, true);
     } else {
       callback(new Error('No permitido por CORS'));


### PR DESCRIPTION
## Summary
- extend CORS whitelist in the backend server to accept any Vercel preview URL for this project

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*
- `npm test --prefix frontend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687cfbd1949c8320ac9e0bf05c6215a7