### PR TITLE
Update frontend URL

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,7 +16,7 @@ JWT_SECRET=5aa3ec7fd3b3d847f08141a3ba15d9a6f134e9a6580dbc970e2fd40938c5f75ebbc0b
 CLIENT_URL=http://localhost:5173
 
 # Dominios permitidos para CORS (separados por comas)
-ALLOWED_ORIGINS=http://localhost:5173,https://apppatin-frontend.onrender.com
+ALLOWED_ORIGINS=http://localhost:5173,https://app-patin-ekcu-dvow4bzs0-gastonmanzurs-projects.vercel.app/
 
 # Credenciales de Google para login OAuth
 GOOGLE_CLIENT_ID=tu-google-client-id

--- a/backend/README.md
+++ b/backend/README.md
@@ -21,7 +21,7 @@ producción sin modificar el código. Asegúrate de separar las URLs con comas,
 por ejemplo:
 
 ```
-ALLOWED_ORIGINS=http://localhost:5173,https://apppatin-frontend.onrender.com
+ALLOWED_ORIGINS=http://localhost:5173,https://app-patin-ekcu-dvow4bzs0-gastonmanzurs-projects.vercel.app/
 ```
 
 Además debes definir `GOOGLE_CLIENT_ID` con el ID de cliente OAuth de Google si

--- a/backend/server.js
+++ b/backend/server.js
@@ -22,7 +22,7 @@ const allowedOrigins = process.env.ALLOWED_ORIGINS
   ];
 
 // Permitir cualquier dominio de preview generado por Vercel para este proyecto
-const vercelPreviewRegex = https://app-patin-ekcu-orp9r397w-gastonmanzurs-projects.vercel.app/;
+const vercelPreviewRegex = /^https:\/\/app-patin-ekcu-dvow4bzs0-gastonmanzurs-projects\.vercel\.app\/?$/;
 
 app.use(cors({
   origin: function (origin, callback) {

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,7 +14,7 @@ If you are developing a production application, we recommend using TypeScript wi
 ## Environment setup
 
 Create a `.env` file in this folder based on `.env.example`. Set `VITE_GOOGLE_CLIENT_ID` to your Google OAuth Client ID.
-Make sure that the client ID allows your deployment domain (e.g. `https://apppatin-frontend.onrender.com`) under "Authorized JavaScript origins" in the Google Cloud console.
+Make sure that the client ID allows your deployment domain (e.g. `https://app-patin-ekcu-dvow4bzs0-gastonmanzurs-projects.vercel.app/`) under "Authorized JavaScript origins" in the Google Cloud console.
 
 If `VITE_GOOGLE_CLIENT_ID` is not set when the app is built, the Google login button will be disabled and a warning will appear in the browser console.
 


### PR DESCRIPTION
## Summary
- update allowed frontend URL in docs and config
- fix server preview URL to new domain

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint` in `frontend` *(fails: cannot find '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687d0ccbd478832085583f29154da795