### PR TITLE
Fix Express wildcard path

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -29,7 +29,7 @@ const corsOptions = {
 };
 
 app.use(cors(corsOptions));
-app.options('*', cors(corsOptions));
+app.options('/*path', cors(corsOptions));
 
 // Rutas
 app.use('/api/auth', require('./routes/authRoutes'));


### PR DESCRIPTION
## Summary
- update Express CORS options route to use named wildcard

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node server.js` *(fails to connect to DB but no path-to-regexp error)*

------
https://chatgpt.com/codex/tasks/task_e_687d601eaea48320ba32d7322364c515