### PR TITLE
Fix path-to-regexp error

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -19,7 +19,7 @@ app.use(cors({
   credentials: true,
   optionsSuccessStatus: 200
 }));
-app.options('*', cors()); // para responder a preflight OPTIONS
+// Preflight requests handled automatically by cors middleware in Express 5
 
 // Rutas
 app.use('/api/auth', require('./routes/authRoutes'));


### PR DESCRIPTION
## Summary
- remove invalid wildcard route from Express CORS setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e4633317c832097ce5c71cc161156