### PR TITLE
Fix wildcard route for Express 5

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -33,7 +33,7 @@ app.use(cors({
   optionsSuccessStatus: 200,
 }));
 // Handle preflight requests for all routes
-app.options('*', cors());
+app.options('/*any', cors());
 // Preflight requests handled automatically by cors middleware in Express 5
 
 // Rutas


### PR DESCRIPTION
## Summary
- fix preflight wildcard path for Express 5 compatibility

## Testing
- `node backend/server.js`

------
https://chatgpt.com/codex/tasks/task_e_687ee506548c832082529d8bd5e2eebc