### PR TITLE
Fix MongoDB URI example

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,30 +1,27 @@
+# Cadena de conexión a MongoDB (incluye el nombre de la base de datos)
+MONGO_URI=mongodb://localhost:27017/appdb
+# Ejemplo para MongoDB Atlas
+# MONGODB_URI=mongodb+srv://usuario:contraseña@cluster0.mongodb.net/appdb?retryWrites=true&w=majority
 
-MONGO_URI=mongodb://localhost:27017/MONGODB_URI
-MONGODB_URI=mongodb+srv://gastonmanzur:gastonmanzur@cluster0.0sd1y.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0
-
-# Cadena de conexión a MongoDB
-MONGODB_URI=mongodb://localhost:27017/MONGODB_URI
-
->>>>>>> faa63ca3091ce50a06ab96ffce9e00676a98e169
 PORT=5000
 
 # Secretos para JWT y sesiones
-SESSION_SECRET=5aa3ec7fd3b3d847f08141a3ba15d9a6f134e9a6580dbc970e2fd40938c5f75ebbc0b630e80e31de9e0012a040a50cd968f2dd3901bd0bc0ccc38ba471d6ce7f
-JWT_SECRET=5aa3ec7fd3b3d847f08141a3ba15d9a6f134e9a6580dbc970e2fd40938c5f75ebbc0b630e80e31de9e0012a040a50cd968f2dd3901bd0bc0ccc38ba471d6ce0f
+SESSION_SECRET=your-session-secret
+JWT_SECRET=your-jwt-secret
 
 # URL del frontend para generar enlaces de verificación
 CLIENT_URL=http://localhost:5173
 
 # Dominios permitidos para CORS (separados por comas)
-ALLOWED_ORIGINS=http://localhost:5173,https://app-patin-ekcu-qvkdq556v-gastonmanzurs-projects.vercel.app/
+ALLOWED_ORIGINS=http://localhost:5173
 
 # Credenciales de Google para login OAuth
 GOOGLE_CLIENT_ID=tu-google-client-id
 GOOGLE_CLIENT_SECRET=tu-google-client-secret
 
 # Cuenta utilizada para el envío de correos
-EMAIL_USER=pruebaappsgmanzur@gmail.com
-EMAIL_PASS=jykjhihxoryhihxf
+EMAIL_USER=tu-correo@gmail.com
+EMAIL_PASS=tu-password
 
 # Código especial solicitado al registrar técnicos/delegados
 CODIGO_ESPECIAL=Tecnico-delegado

--- a/backend/README.md
+++ b/backend/README.md
@@ -5,7 +5,12 @@ variables de entorno necesarias.
 
 El servicio de base de datos utiliza la variable `MONGO_URI` (o `MONGODB_URI`)
 para conectarse a MongoDB. Asegúrate de establecerla con la cadena de conexión
-apropiada.
+apropiada e **incluye el nombre de tu base de datos** en la URI. Un ejemplo de
+URI válida sería:
+
+```
+MONGO_URI=mongodb+srv://usuario:contraseña@cluster0.mongodb.net/mi_basedatos?retryWrites=true&w=majority
+```
 
 Para empezar puedes copiar el archivo `.env.example` como `.env` y rellenar sus
 valores. Si obtienes errores de DNS al usar una URI `mongodb+srv://`, cambia a


### PR DESCRIPTION
## Summary
- clean up backend env example
- clarify README to include the DB name in the MongoDB URI

## Testing
- `npm test` in `backend`
- `npm test` in `frontend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687ee8c0a2888320b2b33cb22fbad630